### PR TITLE
Allow mocking of Win32 calls that take 9 and 13 arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,15 @@ ON_MODULE_FUNC_CALL(GetProcessIdOfThread, _).WillByDefault(Invoke([&](HANDLE han
 }));
 ```
 
+### 3a. You can also use the `REAL_MODULE_FUNC` macro to get a reference to the original function without calling it:
+
+This can be useful to create a mock that calls through to the real function, but is still instrumented.
+
+```cpp
+ON_MODULE_FUNC_CALL(GetProcessIdOfThread, _).WillByDefault(Invoke(REAL_MODULE_FUNC(GetProcessIdOfThread)));
+EXPECT_MODULE_FUNC_CALL(GetProcessIdOfThread, _).Times(1);
+```
+
 #### 4. If you need to use the mock function in multiple tests with different expectations, you can clear the previous expectations and verify them by using the `VERIFY_AND_CLEAR_MODULE_FUNC_EXPECTATIONS` macro:
 
 ```cpp

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ ON_MODULE_FUNC_CALL(GetProcessIdOfThread, _).WillByDefault(Invoke([&](HANDLE han
 }));
 ```
 
-### 3a. You can also use the `REAL_MODULE_FUNC` macro to get a reference to the original function without calling it:
+##### 3a. You can also use the `REAL_MODULE_FUNC` macro to get a reference to the original function without calling it:
 
 This can be useful to create a mock that calls through to the real function, but is still instrumented.
 

--- a/include/gmock-win32.h
+++ b/include/gmock-win32.h
@@ -450,6 +450,69 @@ struct mock_module_##func \
 #define MOCK_MODULE_FUNC8_STDCALL_CONV(m, ...) MOCK_MODULE_FUNC8_CALLCONV(__stdcall, m, __VA_ARGS__)
 #define MOCK_MODULE_FUNC8_CDECL_CONV(m, ...) MOCK_MODULE_FUNC8_CALLCONV(__cdecl, m, __VA_ARGS__)
 
+#define MOCK_MODULE_FUNC9_(tn, constness, ct, func, ...) \
+struct mock_module_##func \
+{ \
+    GMOCK_RESULT_(tn, __VA_ARGS__) ct func( \
+        GMOCK_ARG_(tn, 1, __VA_ARGS__) gmock_a1, \
+        GMOCK_ARG_(tn, 2, __VA_ARGS__) gmock_a2, \
+        GMOCK_ARG_(tn, 3, __VA_ARGS__) gmock_a3, \
+        GMOCK_ARG_(tn, 4, __VA_ARGS__) gmock_a4, \
+        GMOCK_ARG_(tn, 5, __VA_ARGS__) gmock_a5, \
+        GMOCK_ARG_(tn, 6, __VA_ARGS__) gmock_a6, \
+        GMOCK_ARG_(tn, 7, __VA_ARGS__) gmock_a7, \
+        GMOCK_ARG_(tn, 8, __VA_ARGS__) gmock_a8, \
+        GMOCK_ARG_(tn, 9, __VA_ARGS__) gmock_a9) constness \
+    { \
+        GMOCK_MOCKER_(9, constness, func).SetOwnerAndName(this, #func); \
+        return GMOCK_MOCKER_(9, constness, func).Invoke( \
+            gmock_a1, gmock_a2, gmock_a3, gmock_a4, gmock_a5, gmock_a6, gmock_a7, gmock_a8, gmock_a9); \
+    } \
+    ::testing::MockSpec<__VA_ARGS__> gmock_##func( \
+        GMOCK_MATCHER_(tn, 1, __VA_ARGS__) gmock_a1, \
+        GMOCK_MATCHER_(tn, 2, __VA_ARGS__) gmock_a2, \
+        GMOCK_MATCHER_(tn, 3, __VA_ARGS__) gmock_a3, \
+        GMOCK_MATCHER_(tn, 4, __VA_ARGS__) gmock_a4, \
+        GMOCK_MATCHER_(tn, 5, __VA_ARGS__) gmock_a5, \
+        GMOCK_MATCHER_(tn, 6, __VA_ARGS__) gmock_a6, \
+        GMOCK_MATCHER_(tn, 7, __VA_ARGS__) gmock_a7, \
+        GMOCK_MATCHER_(tn, 8, __VA_ARGS__) gmock_a8, \
+        GMOCK_MATCHER_(tn, 9, __VA_ARGS__) gmock_a9) constness \
+    { \
+        GMOCK_MOCKER_(9, constness, func).RegisterOwner(this); \
+        return GMOCK_MOCKER_(9, constness, func).With( \
+            gmock_a1, gmock_a2, gmock_a3, gmock_a4, gmock_a5, gmock_a6, gmock_a7, gmock_a8, gmock_a9); \
+    } \
+    mutable ::testing::FunctionMocker<__VA_ARGS__> \
+        GMOCK_MOCKER_(9, constness, func); \
+    static mock_module_##func& instance() \
+    { \
+        static ::testing::NiceMock< mock_module_##func > obj; \
+        return obj; \
+    } \
+    static GMOCK_RESULT_(tn, __VA_ARGS__) ct stub( \
+        GMOCK_ARG_(tn, 1, __VA_ARGS__) gmock_a1, \
+        GMOCK_ARG_(tn, 2, __VA_ARGS__) gmock_a2, \
+        GMOCK_ARG_(tn, 3, __VA_ARGS__) gmock_a3, \
+        GMOCK_ARG_(tn, 4, __VA_ARGS__) gmock_a4, \
+        GMOCK_ARG_(tn, 5, __VA_ARGS__) gmock_a5, \
+        GMOCK_ARG_(tn, 6, __VA_ARGS__) gmock_a6, \
+        GMOCK_ARG_(tn, 7, __VA_ARGS__) gmock_a7, \
+        GMOCK_ARG_(tn, 8, __VA_ARGS__) gmock_a8, \
+        GMOCK_ARG_(tn, 9, __VA_ARGS__) gmock_a9) \
+    { \
+        return mock_module_##func::instance().func( \
+            gmock_a1, gmock_a2, gmock_a3, gmock_a4, gmock_a5, gmock_a6, gmock_a7, gmock_a8, gmock_a9); \
+    } \
+    static void* oldFn_; \
+}; void* mock_module_##func::oldFn_ = nullptr;
+
+#define MOCK_MODULE_FUNC9(m, ...) MOCK_MODULE_FUNC9_(, , , m, __VA_ARGS__)
+#define MOCK_MODULE_FUNC9_CALLCONV(ct, m, ...) MOCK_MODULE_FUNC9_(, , ct, m, __VA_ARGS__)
+
+#define MOCK_MODULE_FUNC9_STDCALL_CONV(m, ...) MOCK_MODULE_FUNC9_CALLCONV(__stdcall, m, __VA_ARGS__)
+#define MOCK_MODULE_FUNC9_CDECL_CONV(m, ...) MOCK_MODULE_FUNC9_CALLCONV(__cdecl, m, __VA_ARGS__)
+
 #define MOCK_MODULE_FUNC13_(tn, constness, ct, func, ...) \
 struct mock_module_##func \
 { \

--- a/include/gmock-win32.h
+++ b/include/gmock-win32.h
@@ -375,7 +375,7 @@ struct mock_module_##func \
         GMOCK_ARG_(tn, 3, __VA_ARGS__) gmock_a3, \
         GMOCK_ARG_(tn, 4, __VA_ARGS__) gmock_a4, \
         GMOCK_ARG_(tn, 5, __VA_ARGS__) gmock_a5, \
-        GMOCK_ARG_(tn, 6, __VA_ARGS__) gmock_a6) \
+        GMOCK_ARG_(tn, 6, __VA_ARGS__) gmock_a6, \
         GMOCK_ARG_(tn, 7, __VA_ARGS__) gmock_a7) \
     { \
         return mock_module_##func::instance().func( \
@@ -434,8 +434,8 @@ struct mock_module_##func \
         GMOCK_ARG_(tn, 3, __VA_ARGS__) gmock_a3, \
         GMOCK_ARG_(tn, 4, __VA_ARGS__) gmock_a4, \
         GMOCK_ARG_(tn, 5, __VA_ARGS__) gmock_a5, \
-        GMOCK_ARG_(tn, 6, __VA_ARGS__) gmock_a6) \
-        GMOCK_ARG_(tn, 7, __VA_ARGS__) gmock_a7) \
+        GMOCK_ARG_(tn, 6, __VA_ARGS__) gmock_a6, \
+        GMOCK_ARG_(tn, 7, __VA_ARGS__) gmock_a7, \
         GMOCK_ARG_(tn, 8, __VA_ARGS__) gmock_a8) \
     { \
         return mock_module_##func::instance().func( \

--- a/include/gmock-win32.h
+++ b/include/gmock-win32.h
@@ -623,8 +623,11 @@ void mockModule_restoreModuleFunc (void*, void*, void**);
     } \
     ON_CALL(mock_module_##func::instance(), func(__VA_ARGS__))
 
+#define REAL_MODULE_FUNC(func) \
+    reinterpret_cast< decltype(&func) >(mock_module_##func::oldFn_)
+
 #define INVOKE_REAL_MODULE_FUNC(func, ...) \
-    reinterpret_cast< decltype(&func) >(mock_module_##func::oldFn_)(__VA_ARGS__)
+    REAL_MODULE_FUNC(func)(__VA_ARGS__)
 
 #define VERIFY_AND_CLEAR_MODULE_FUNC_EXPECTATIONS(func) \
     ::testing::Mock::VerifyAndClearExpectations(&mock_module_##func::instance())

--- a/include/gmock-win32.h
+++ b/include/gmock-win32.h
@@ -450,13 +450,88 @@ struct mock_module_##func \
 #define MOCK_MODULE_FUNC8_STDCALL_CONV(m, ...) MOCK_MODULE_FUNC8_CALLCONV(__stdcall, m, __VA_ARGS__)
 #define MOCK_MODULE_FUNC8_CDECL_CONV(m, ...) MOCK_MODULE_FUNC8_CALLCONV(__cdecl, m, __VA_ARGS__)
 
+#define MOCK_MODULE_FUNC13_(tn, constness, ct, func, ...) \
+struct mock_module_##func \
+{ \
+    GMOCK_RESULT_(tn, __VA_ARGS__) ct func( \
+        GMOCK_ARG_(tn, 1, __VA_ARGS__) gmock_a1, \
+        GMOCK_ARG_(tn, 2, __VA_ARGS__) gmock_a2, \
+        GMOCK_ARG_(tn, 3, __VA_ARGS__) gmock_a3, \
+        GMOCK_ARG_(tn, 4, __VA_ARGS__) gmock_a4, \
+        GMOCK_ARG_(tn, 5, __VA_ARGS__) gmock_a5, \
+        GMOCK_ARG_(tn, 6, __VA_ARGS__) gmock_a6, \
+        GMOCK_ARG_(tn, 7, __VA_ARGS__) gmock_a7, \
+        GMOCK_ARG_(tn, 8, __VA_ARGS__) gmock_a8, \
+        GMOCK_ARG_(tn, 9, __VA_ARGS__) gmock_a9, \
+        GMOCK_ARG_(tn, 10, __VA_ARGS__) gmock_a10, \
+        GMOCK_ARG_(tn, 11, __VA_ARGS__) gmock_a11, \
+        GMOCK_ARG_(tn, 12, __VA_ARGS__) gmock_a12, \
+        GMOCK_ARG_(tn, 13, __VA_ARGS__) gmock_a13) constness \
+    { \
+        GMOCK_MOCKER_(13, constness, func).SetOwnerAndName(this, #func); \
+        return GMOCK_MOCKER_(13, constness, func).Invoke( \
+            gmock_a1, gmock_a2, gmock_a3, gmock_a4, gmock_a5, gmock_a6, gmock_a7, gmock_a8, gmock_a9, gmock_a10, gmock_a11, gmock_a12, gmock_a13); \
+    } \
+    ::testing::MockSpec<__VA_ARGS__> gmock_##func( \
+        GMOCK_MATCHER_(tn, 1, __VA_ARGS__) gmock_a1, \
+        GMOCK_MATCHER_(tn, 2, __VA_ARGS__) gmock_a2, \
+        GMOCK_MATCHER_(tn, 3, __VA_ARGS__) gmock_a3, \
+        GMOCK_MATCHER_(tn, 4, __VA_ARGS__) gmock_a4, \
+        GMOCK_MATCHER_(tn, 5, __VA_ARGS__) gmock_a5, \
+        GMOCK_MATCHER_(tn, 6, __VA_ARGS__) gmock_a6, \
+        GMOCK_MATCHER_(tn, 7, __VA_ARGS__) gmock_a7, \
+        GMOCK_MATCHER_(tn, 8, __VA_ARGS__) gmock_a8, \
+        GMOCK_MATCHER_(tn, 9, __VA_ARGS__) gmock_a9, \
+        GMOCK_MATCHER_(tn, 10, __VA_ARGS__) gmock_a10, \
+        GMOCK_MATCHER_(tn, 11, __VA_ARGS__) gmock_a11, \
+        GMOCK_MATCHER_(tn, 12, __VA_ARGS__) gmock_a12, \
+        GMOCK_MATCHER_(tn, 13, __VA_ARGS__) gmock_a13) constness \
+    { \
+        GMOCK_MOCKER_(13, constness, func).RegisterOwner(this); \
+        return GMOCK_MOCKER_(13, constness, func).With( \
+            gmock_a1, gmock_a2, gmock_a3, gmock_a4, gmock_a5, gmock_a6, gmock_a7, gmock_a8, gmock_a9, gmock_a10, gmock_a11, gmock_a12, gmock_a13); \
+    } \
+    mutable ::testing::FunctionMocker<__VA_ARGS__> \
+        GMOCK_MOCKER_(13, constness, func); \
+    static mock_module_##func& instance() \
+    { \
+        static ::testing::NiceMock< mock_module_##func > obj; \
+        return obj; \
+    } \
+    static GMOCK_RESULT_(tn, __VA_ARGS__) ct stub( \
+        GMOCK_ARG_(tn, 1, __VA_ARGS__) gmock_a1, \
+        GMOCK_ARG_(tn, 2, __VA_ARGS__) gmock_a2, \
+        GMOCK_ARG_(tn, 3, __VA_ARGS__) gmock_a3, \
+        GMOCK_ARG_(tn, 4, __VA_ARGS__) gmock_a4, \
+        GMOCK_ARG_(tn, 5, __VA_ARGS__) gmock_a5, \
+        GMOCK_ARG_(tn, 6, __VA_ARGS__) gmock_a6, \
+        GMOCK_ARG_(tn, 7, __VA_ARGS__) gmock_a7, \
+        GMOCK_ARG_(tn, 8, __VA_ARGS__) gmock_a8, \
+        GMOCK_ARG_(tn, 9, __VA_ARGS__) gmock_a9, \
+        GMOCK_ARG_(tn, 10, __VA_ARGS__) gmock_a10, \
+        GMOCK_ARG_(tn, 11, __VA_ARGS__) gmock_a11, \
+        GMOCK_ARG_(tn, 12, __VA_ARGS__) gmock_a12, \
+        GMOCK_ARG_(tn, 13, __VA_ARGS__) gmock_a13) \
+    { \
+        return mock_module_##func::instance().func( \
+            gmock_a1, gmock_a2, gmock_a3, gmock_a4, gmock_a5, gmock_a6, gmock_a7, gmock_a8, gmock_a9, gmock_a10, gmock_a11, gmock_a12, gmock_a13); \
+    } \
+    static void* oldFn_; \
+}; void* mock_module_##func::oldFn_ = nullptr;
+
+#define MOCK_MODULE_FUNC13(m, ...) MOCK_MODULE_FUNC13_(, , , m, __VA_ARGS__)
+#define MOCK_MODULE_FUNC13_CALLCONV(ct, m, ...) MOCK_MODULE_FUNC13_(, , ct, m, __VA_ARGS__)
+
+#define MOCK_MODULE_FUNC13_STDCALL_CONV(m, ...) MOCK_MODULE_FUNC13_CALLCONV(__stdcall, m, __VA_ARGS__)
+#define MOCK_MODULE_FUNC13_CDECL_CONV(m, ...) MOCK_MODULE_FUNC13_CALLCONV(__cdecl, m, __VA_ARGS__)
+
 #define MOCK_MODULE_EXPAND(x) x
 #define MOCK_MODULE_UNITE(x, y) x y
 #define MOCK_MODULE_CONCAT(x, y) x##y
 
 #define MOCK_MODULE_PREFIX(...) 0, ##__VA_ARGS__
-#define MOCK_MODULE_LASTOF10(a, b, c, d, e, f, g, h, i, j, ...)  j
-#define MOCK_MODULE_SUB_NBARG(...) MOCK_MODULE_EXPAND(MOCK_MODULE_LASTOF10(__VA_ARGS__, 8, 7, 6, 5, 4, 3, 2, 1, 0))
+#define MOCK_MODULE_LASTOF15(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, ...)  o
+#define MOCK_MODULE_SUB_NBARG(...) MOCK_MODULE_EXPAND(MOCK_MODULE_LASTOF15(__VA_ARGS__, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0))
 #define MOCK_MODULE_NBARG(...) MOCK_MODULE_SUB_NBARG(MOCK_MODULE_PREFIX(__VA_ARGS__))
 
 #define MOCK_MODULE_OVERLOAD(name, count) MOCK_MODULE_CONCAT(name, count)


### PR DESCRIPTION
Previous max was functionally 6; Fixed macros for 7 and 8, and added macros for 9 and 13 args. (10-12 argument function support not implemented).

Also added the `REAL_MODULE_FUNC()` macro. It's similar to `INVOKE_REAL_MODULE_FUNC(...)`, but lets you reference the function instead of call it. That enables doing something like
```c++
ON_MODULE_FUNC_CALL(CreateEventW, _, _, _, _).WillByDefault(REAL_MODULE_FUNC(CreateEventW));
```