### PR TITLE
[proposed enhancement] Clang compatibility

### DIFF
--- a/include/gmock-win32.h
+++ b/include/gmock-win32.h
@@ -804,12 +804,15 @@ struct mock_module_##func \
 #define MOCK_MODULE_SUB_NBARG(...) MOCK_MODULE_EXPAND(MOCK_MODULE_LASTOF15(__VA_ARGS__, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0))
 #define MOCK_MODULE_NBARG(...) MOCK_MODULE_SUB_NBARG(MOCK_MODULE_PREFIX(__VA_ARGS__))
 
-#define MOCK_MODULE_OVERLOAD(name, count) MOCK_MODULE_CONCAT(name, count)
+#define MOCK_MODULE_OVERLOAD(count_args, conv, signat) MOCK_MODULE_MAKENAME_( count_args, conv )signat
+// Expand before concatenate
+#define MOCK_MODULE_MAKENAME_(count_args, conv) MOCK_MODULE_FUNC##count_args##conv
 #define MOCK_MODULE_FUNC_OVERLOAD(name, ...) MOCK_MODULE_UNITE(MOCK_MODULE_OVERLOAD(name, MOCK_MODULE_NBARG(__VA_ARGS__)), (__VA_ARGS__))
-#define MOCK_MODULE_FUNC(r, m, ...) MOCK_MODULE_OVERLOAD(MOCK_MODULE_FUNC, MOCK_MODULE_NBARG(__VA_ARGS__))##(m, r(__VA_ARGS__))
+#define MOCK_MODULE_FUNC(r, m, ...) MOCK_MODULE_OVERLOAD( MOCK_MODULE_NBARG(__VA_ARGS__), , (m, r(__VA_ARGS__)) )
+#define MOCK_CDECL_FUNC(r, m, ...) MOCK_MODULE_OVERLOAD( MOCK_MODULE_NBARG(__VA_ARGS__), _CDECL_CONV, (m, r(__VA_ARGS__)) )
 
 #define MOCK_STDCALL_FUNC(r, m, ...) \
-	MOCK_MODULE_OVERLOAD(MOCK_MODULE_FUNC, MOCK_MODULE_NBARG(__VA_ARGS__)##_STDCALL_CONV)##(m, r(__VA_ARGS__)) \
+	MOCK_MODULE_OVERLOAD( MOCK_MODULE_NBARG(__VA_ARGS__), _STDCALL_CONV, (m, r(__VA_ARGS__)) ) \
 	__pragma(optimize("", on)) \
 	static void patchModuleFunc_##m() { \
 		::patchModuleFunc_( mock_module_##m::oldFn_, &::m, mock_module_##m::stub ); \
@@ -825,8 +828,6 @@ void patchModuleFunc_(void* mock_module_func_oldFn, TFunc func, TStub stub) {
 			, reinterpret_cast< void* >( stub ) 
 			, &mock_module_func_oldFn);
 }
-
-#define MOCK_CDECL_FUNC(r, m, ...) MOCK_MODULE_OVERLOAD(MOCK_MODULE_FUNC, MOCK_MODULE_NBARG(__VA_ARGS__)##__CDECL_CONV)##(m, r(__VA_ARGS__))
 
 void mockModule_patchModuleFunc   (void*, void*, void**);
 void mockModule_restoreModuleFunc (void*, void*, void**);


### PR DESCRIPTION
# **Clang compatibility**
This PR add Clang compatibility
## **Description**
4 macros have been changed, one new one has been added. Fixed compilation error issue in clang.

---
### **Additional context**
## Expected Behavior
```gtest
[==========] Running 1 test from 1 test suite.
[----------] Global test environment set-up.
[----------] 1 test from test
[ RUN      ] test.test
[       OK ] test.test (2 ms)
[----------] 1 test from test (3 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test suite ran. (6 ms total)
[  PASSED  ] 1 test.
```

## Actual Behavior
Compilation error issue
```clang_output
clang_macro.cpp(28,1): error: pasting formed ')(', an invalid preprocessing token [-Winvalid-token-paste]
MOCK_MODULE_FUNC( UINT, GetACP );
^
gmock-win32\include\gmock-win32.h(809,107): note: expanded from macro 'MOCK_MODULE_FUNC'
  ...m, ...) MOCK_MODULE_OVERLOAD(MOCK_MODULE_FUNC, MOCK_MODULE_NBARG(__VA_ARGS__))##(m, r(__VA_ARGS__))
                                                                                   ^
clang_macro.cpp(29,1): error: pasting formed ')_STDCALL_CONV', an invalid preprocessing token
      [-Winvalid-token-paste]
MOCK_STDCALL_FUNC( HWND, GetActiveWindow );
^
gmock-win32\include\gmock-win32.h(811,107): note: expanded from macro
      'MOCK_STDCALL_FUNC'
  ...m, ...) MOCK_MODULE_OVERLOAD(MOCK_MODULE_FUNC, MOCK_MODULE_NBARG(__VA_ARGS__)##_STDCALL_CONV)##(m, r...
                                                                                  ^
clang_macro.cpp(29,1): error: pasting formed ')(', an invalid preprocessing token [-Winvalid-token-paste]
gmock-win32\include\gmock-win32.h(811,123): note: expanded from macro
      'MOCK_STDCALL_FUNC'
  ...m, ...) MOCK_MODULE_OVERLOAD(MOCK_MODULE_FUNC, MOCK_MODULE_NBARG(__VA_ARGS__)##_STDCALL_CONV)##(m, r...
                                                                                                  ^
clang_macro.cpp(29,1): error: unknown type name 'MOCK_MODULE_FUNC0'
gmock-win32\include\gmock-win32.h(811,38): note: expanded from macro 'MOCK_STDCALL_FUNC'
#define MOCK_STDCALL_FUNC(r, m, ...) MOCK_MODULE_OVERLOAD(MOCK_MODULE_FUNC, MOCK_MODULE_NBARG(__VA_A...
                                     ^
gmock-win32\include\gmock-win32.h(807,43): note: expanded from macro
      'MOCK_MODULE_OVERLOAD'
#define MOCK_MODULE_OVERLOAD(name, count) MOCK_MODULE_CONCAT(name, count)
                                          ^
gmock-win32\include\gmock-win32.h(800,34): note: expanded from macro
      'MOCK_MODULE_CONCAT'
#define MOCK_MODULE_CONCAT(x, y) x##y
                                 ^
<scratch space>(60,1): note: expanded from here
...
```

## Steps to Reproduce the Problem

  1. Single-file example
`clang_macro.cpp`
```cpp
#pragma comment( lib, "kernel32" )
#pragma comment( lib, "user32" )
#include "..\src\gtest\src\gtest_main.cc"
#include "..\src\gtest\gtest-all.cc"
#include "..\src\gmock\gmock-all.cc"
#include "..\..\src\gmock-win32.cpp"

/* // Patch
// Replacing four macros.
#undef MOCK_MODULE_OVERLOAD
#undef MOCK_MODULE_FUNC
#undef MOCK_STDCALL_FUNC
#undef MOCK_CDECL_FUNC
// Expand before concatenate
#define MOCK_MODULE_MAKENAME_(count_args, conv) MOCK_MODULE_FUNC##count_args##conv
// Overload with expand
#define MOCK_MODULE_OVERLOAD(count_args, conv, signat) MOCK_MODULE_MAKENAME_( count_args, conv )signat
// These are the main external macros
#define MOCK_MODULE_FUNC(ret, func_name, ...) \
	MOCK_MODULE_OVERLOAD( MOCK_MODULE_NBARG(__VA_ARGS__), , (func_name, ret(__VA_ARGS__)) )
#define MOCK_STDCALL_FUNC(ret, func_name, ...) \
	MOCK_MODULE_OVERLOAD( MOCK_MODULE_NBARG(__VA_ARGS__), _STDCALL_CONV, (func_name, ret(__VA_ARGS__)) )
#define MOCK_CDECL_FUNC(ret, func_name, ...) \
	MOCK_MODULE_OVERLOAD( MOCK_MODULE_NBARG(__VA_ARGS__), _CDECL_CONV, (func_name, ret(__VA_ARGS__)) )
*/

MOCK_MODULE_FUNC( UINT, GetACP );
MOCK_STDCALL_FUNC( HWND, GetActiveWindow );
MOCK_CDECL_FUNC( HWND, GetCapture );
TEST(test, test) { 
	EXPECT_MODULE_FUNC_CALL( GetACP );
	EXPECT_MODULE_FUNC_CALL( GetActiveWindow );
	EXPECT_MODULE_FUNC_CALL( GetCapture );
	GetACP( );
	GetActiveWindow( );
	GetCapture( );
}
```
  2. Building in cmd line

Include path to googletest and current project
```cmd
set googletest=googletest\gmock\include
set gmock-win32=gmock-win32\include
```
Building for clang version 12.0.0 from Msvc 2019 
```cmd
clang-cl clang_macro.cpp /EHsc /I"%googletest%" /I"%gmock-win32%" -Wno-microsoft-cast -Wno-microsoft-include
```
Building for clang version 15.0.1, alternative
```cmd
C:\LLVM\bin\clang clang_macro.cpp -I"%googletest%" -I"%gmock-win32%" -Wno-microsoft-cast -Wno-microsoft-include
```

  3. Run `clang_macro.exe`  or `a.exe` 

## Specifications

  - Version: latest
  - Platform: Windows
  - Subsystem:  Visual Studio Community 2019
  