### PR TITLE
[proposed bug] Optimize off

### DIFF
--- a/include/gmock-win32.h
+++ b/include/gmock-win32.h
@@ -810,15 +810,15 @@ struct mock_module_##func \
 
 #define MOCK_STDCALL_FUNC(r, m, ...) \
 	MOCK_MODULE_OVERLOAD(MOCK_MODULE_FUNC, MOCK_MODULE_NBARG(__VA_ARGS__)##_STDCALL_CONV)##(m, r(__VA_ARGS__)) \
-	_Pragma( "optimize( \"\", off )" ) \
+	__pragma(optimize("", on)) \
 	static void patchModuleFunc_##m() { \
 		::patchModuleFunc_( mock_module_##m::oldFn_, &::m, mock_module_##m::stub ); \
 	} \
-	_Pragma( "optimize( \"\", on )" )
+	__pragma(optimize("", off))
 
 // Hidden from optimizer
 template <typename TFunc, typename TStub>
-static void patchModuleFunc_(void* mock_module_func_oldFn, TFunc func, TStub stub) { 
+void patchModuleFunc_(void* mock_module_func_oldFn, TFunc func, TStub stub) { 
 	if (!mock_module_func_oldFn) 
 		mockModule_patchModuleFunc( 
 			func 


### PR DESCRIPTION
# **Disable optimization for sensitive code sections**
This is a PR fix for a hooked function with more than one argument when optimization is enabled.
## **Description**
2 macros have been changed.
If the PR is accepted, I'll do the same for the rest of the macros.

---
### **Additional context**
Reproducible only in:
arch x86 + `link.exe /LTCG:incremental` + [`cl.exe /Gy /GL /Ox` or `cl.exe /Gy /GL /O2`]
#### A Cause
Last line from here
```cpp
EXPECT_MODULE_FUNC_CALL( RegCloseKey, ::testing::_ );
RegCloseKey( 0 );
```
will be translate to
```asm
...
007366D4  push        0  
007366D6  call        esi  
```
due to reuse of the RegCloseKey address in the previous line
```cpp
EXPECT_MODULE_FUNC_CALL( RegCloseKey, ::testing::_ );
```
the original function will be called.

## Expected Behavior
```googletest
[==========] Running 1 test from 1 test suite.
[----------] Global test environment set-up.
[----------] 1 test from optimize_off
[ RUN      ] optimize_off.test
[       OK ] optimize_off.test (1 ms)
[----------] 1 test from optimize_off (2 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test suite ran. (3 ms total)
[  PASSED  ] 1 test.
```

## Actual Behavior
```googletest
[==========] Running 1 test from 1 test suite.
[----------] Global test environment set-up.
[----------] 1 test from optimize_off
[ RUN      ] optimize_off.test
[       OK ] optimize_off.test (0 ms)
[----------] 1 test from optimize_off (0 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test suite ran. (2 ms total)
[  PASSED  ] 1 test.
C:\Prj\_PullRequest\gmock-win32\_changes\optimize_off\optimize_off.cpp(17): error: Actual function call count doesn't match EXPECT_CALL(mock_module_RegCloseKey::instance(), RegCloseKey(::testing::_))...
         Expected: to be called once
           Actual: never called - unsatisfied and active
```

## Steps to Reproduce the Problem

  1. Single-file example
`optimize_off.cpp`
```cpp
#pragma comment( lib, "Advapi32" )
#include "..\src\gtest\src\gtest_main.cc"
#include "..\src\gtest\gtest-all.cc"
#include "..\src\gmock\gmock-all.cc"
#include "..\..\src\gmock-win32.cpp"

MOCK_STDCALL_FUNC(LSTATUS, RegCloseKey, HKEY hKey);
TEST(optimize_off, test) { 
	EXPECT_MODULE_FUNC_CALL( RegCloseKey, ::testing::_ );
	RegCloseKey( 0 );
}
```
  2. Building in cmd line

Include path to googletest and current project
```cmd
set googletest=googletest\gmock\include
set gmock-win32=gmock-win32\include
```
Building, release x86 default Msvc options
```cmd
@REM Visual Studio 2019 Community
%comspec% /k "C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build\vcvars32.bat"
cl optimize_off.cpp /Gy /GL /Ox /EHsc /I"%googletest%" /I"%gmock-win32%" /link /LTCG:incremental
```
  3. Run `optimize_off.exe`

## Specifications

  - Version: latest
  - Platform: Windows
  - Subsystem:  Visual Studio Community 2019
  