### PR TITLE
[bug] deadlock in the setup of expectations for the mocked GetCurrentThreadId function

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,10 +145,12 @@ Here are some examples of library usage: [gmock-win32-sample](https://github.com
 
 # Version history
 
-### Version 1.1.0 (29 August 2023)
+## Version 1.1.0 (29 August 2023)
 - Added support for functions with 9-13 parameters
-- Added REAL_MODULE_FUNC macro
+- Added `REAL_MODULE_FUNC` macro
 - Fixed problem with Windows ApiSet DLL functions redirection
+
+## Old versions:
 
 ### Version 1.0.4 (19 March 2023)
 - Added support for googletest v1.11.0 / v1.12.1 / v1.13.0

--- a/README.md
+++ b/README.md
@@ -131,7 +131,9 @@ After mock expectations set:
     * `googletest 1.11.0`
     * `googletest 1.12.1`
     * `googletest 1.13.0`
+    * `googletest 1.14.0`
 - Compiled with `Visual Studio 2015` Update3 `v140 toolset` x86 / x64
+- Microsoft Windows Version: 10.0.19045.3324
 
 # Related Open Source Projects
 

--- a/README.md
+++ b/README.md
@@ -135,6 +135,10 @@ After mock expectations set:
 - Compiled with `Visual Studio 2015` Update3 `v140 toolset` x86 / x64
 - Microsoft Windows Version: 10.0.19045.3324
 
+# Samples
+
+Here are some examples of library usage: [gmock-win32-sample](https://github.com/smalti/gmock-win32-sample)
+
 # Related Open Source Projects
 
 [GoogleTest](https://github.com/google/googletest)

--- a/README.md
+++ b/README.md
@@ -141,6 +141,11 @@ After mock expectations set:
 
 # Version history
 
+### Version 1.1.0 (29 August 2023)
+- Added support for functions with 9-13 parameters
+- Added REAL_MODULE_FUNC macro
+- Fixed problem with Windows ApiSet DLL functions redirection
+
 ### Version 1.0.4 (19 March 2023)
 - Added support for googletest v1.11.0 / v1.12.1 / v1.13.0
 

--- a/include/gmock-win32.h
+++ b/include/gmock-win32.h
@@ -32,10 +32,7 @@ namespace detail {
 
     extern thread_local int lock;
 
-    struct proxy_base
-    {
-        ~proxy_base() noexcept;
-    };
+    struct proxy_base{ ~proxy_base() noexcept; };
 
     template< typename Reference >
     struct ref_proxy final : proxy_base
@@ -133,8 +130,17 @@ struct mock_module_##func \
     static GMOCK_RESULT_(tn, __VA_ARGS__) ct stub( \
         GMOCK_ARG_(tn, 1, __VA_ARGS__) gmock_a1) \
     { \
-        return mock_module_##func::instance().func( \
-            gmock_a1); \
+        if (gmock_win32::detail::lock) \
+        { \
+            return reinterpret_cast< decltype(&stub) >(mock_module_##func::oldFn_)( \
+                gmock_a1); \
+        } \
+        else \
+        { \
+            const gmock_win32::bypass_mocks blockMocks{ }; \
+            return instance().func( \
+                gmock_a1); \
+        } \
     } \
     static void* oldFn_; \
 }; void* mock_module_##func::oldFn_ = nullptr;
@@ -175,8 +181,17 @@ struct mock_module_##func \
         GMOCK_ARG_(tn, 1, __VA_ARGS__) gmock_a1, \
         GMOCK_ARG_(tn, 2, __VA_ARGS__) gmock_a2) \
     { \
-        return mock_module_##func::instance().func( \
-            gmock_a1, gmock_a2); \
+        if (gmock_win32::detail::lock) \
+        { \
+            return reinterpret_cast< decltype(&stub) >(mock_module_##func::oldFn_)( \
+                gmock_a1, gmock_a2); \
+        } \
+        else \
+        { \
+            const gmock_win32::bypass_mocks blockMocks{ }; \
+            return instance().func( \
+                gmock_a1, gmock_a2); \
+        } \
     } \
     static void* oldFn_; \
 }; void* mock_module_##func::oldFn_ = nullptr;
@@ -220,8 +235,17 @@ struct mock_module_##func \
         GMOCK_ARG_(tn, 2, __VA_ARGS__) gmock_a2, \
         GMOCK_ARG_(tn, 3, __VA_ARGS__) gmock_a3) \
     { \
-        return mock_module_##func::instance().func( \
-            gmock_a1, gmock_a2, gmock_a3); \
+        if (gmock_win32::detail::lock) \
+        { \
+            return reinterpret_cast< decltype(&stub) >(mock_module_##func::oldFn_)( \
+                gmock_a1, gmock_a2, gmock_a3); \
+        } \
+        else \
+        { \
+            const gmock_win32::bypass_mocks blockMocks{ }; \
+            return instance().func( \
+                gmock_a1, gmock_a2, gmock_a3); \
+        } \
     } \
     static void* oldFn_; \
 }; void* mock_module_##func::oldFn_ = nullptr;
@@ -268,8 +292,17 @@ struct mock_module_##func \
         GMOCK_ARG_(tn, 3, __VA_ARGS__) gmock_a3, \
         GMOCK_ARG_(tn, 4, __VA_ARGS__) gmock_a4) \
     { \
-        return mock_module_##func::instance().func( \
-            gmock_a1, gmock_a2, gmock_a3, gmock_a4); \
+        if (gmock_win32::detail::lock) \
+        { \
+            return reinterpret_cast< decltype(&stub) >(mock_module_##func::oldFn_)( \
+                gmock_a1, gmock_a2, gmock_a3, gmock_a4); \
+        } \
+        else \
+        { \
+            const gmock_win32::bypass_mocks blockMocks{ }; \
+            return instance().func( \
+                gmock_a1, gmock_a2, gmock_a3, gmock_a4); \
+        } \
     } \
     static void* oldFn_; \
 }; void* mock_module_##func::oldFn_ = nullptr;
@@ -319,8 +352,17 @@ struct mock_module_##func \
         GMOCK_ARG_(tn, 4, __VA_ARGS__) gmock_a4, \
         GMOCK_ARG_(tn, 5, __VA_ARGS__) gmock_a5) \
     { \
-        return mock_module_##func::instance().func( \
-            gmock_a1, gmock_a2, gmock_a3, gmock_a4, gmock_a5); \
+        if (gmock_win32::detail::lock) \
+        { \
+            return reinterpret_cast< decltype(&stub) >(mock_module_##func::oldFn_)( \
+                gmock_a1, gmock_a2, gmock_a3, gmock_a4, gmock_a5); \
+        } \
+        else \
+        { \
+            const gmock_win32::bypass_mocks blockMocks{ }; \
+            return instance().func( \
+                gmock_a1, gmock_a2, gmock_a3, gmock_a4, gmock_a5); \
+        } \
     } \
     static void* oldFn_; \
 }; void* mock_module_##func::oldFn_ = nullptr;
@@ -373,8 +415,17 @@ struct mock_module_##func \
         GMOCK_ARG_(tn, 5, __VA_ARGS__) gmock_a5, \
         GMOCK_ARG_(tn, 6, __VA_ARGS__) gmock_a6) \
     { \
-        return mock_module_##func::instance().func( \
-            gmock_a1, gmock_a2, gmock_a3, gmock_a4, gmock_a5, gmock_a6); \
+        if (gmock_win32::detail::lock) \
+        { \
+            return reinterpret_cast< decltype(&stub) >(mock_module_##func::oldFn_)( \
+                gmock_a1, gmock_a2, gmock_a3, gmock_a4, gmock_a5, gmock_a6); \
+        } \
+        else \
+        { \
+            const gmock_win32::bypass_mocks blockMocks{ }; \
+            return instance().func( \
+                gmock_a1, gmock_a2, gmock_a3, gmock_a4, gmock_a5, gmock_a6); \
+        } \
     } \
     static void* oldFn_; \
 }; void* mock_module_##func::oldFn_ = nullptr;
@@ -430,8 +481,17 @@ struct mock_module_##func \
         GMOCK_ARG_(tn, 6, __VA_ARGS__) gmock_a6, \
         GMOCK_ARG_(tn, 7, __VA_ARGS__) gmock_a7) \
     { \
-        return mock_module_##func::instance().func( \
-            gmock_a1, gmock_a2, gmock_a3, gmock_a4, gmock_a5, gmock_a6, gmock_a7); \
+        if (gmock_win32::detail::lock) \
+        { \
+            return reinterpret_cast< decltype(&stub) >(mock_module_##func::oldFn_)( \
+                gmock_a1, gmock_a2, gmock_a3, gmock_a4, gmock_a5, gmock_a6, gmock_a7); \
+        } \
+        else \
+        { \
+            const gmock_win32::bypass_mocks blockMocks{ }; \
+            return instance().func( \
+                gmock_a1, gmock_a2, gmock_a3, gmock_a4, gmock_a5, gmock_a6, gmock_a7); \
+        } \
     } \
     static void* oldFn_; \
 }; void* mock_module_##func::oldFn_ = nullptr;
@@ -490,8 +550,17 @@ struct mock_module_##func \
         GMOCK_ARG_(tn, 7, __VA_ARGS__) gmock_a7, \
         GMOCK_ARG_(tn, 8, __VA_ARGS__) gmock_a8) \
     { \
-        return mock_module_##func::instance().func( \
-            gmock_a1, gmock_a2, gmock_a3, gmock_a4, gmock_a5, gmock_a6, gmock_a7, gmock_a8); \
+        if (gmock_win32::detail::lock) \
+        { \
+            return reinterpret_cast< decltype(&stub) >(mock_module_##func::oldFn_)( \
+                gmock_a1, gmock_a2, gmock_a3, gmock_a4, gmock_a5, gmock_a6, gmock_a7, gmock_a8); \
+        } \
+        else \
+        { \
+            const gmock_win32::bypass_mocks blockMocks{ }; \
+            return instance().func( \
+                gmock_a1, gmock_a2, gmock_a3, gmock_a4, gmock_a5, gmock_a6, gmock_a7, gmock_a8); \
+        } \
     } \
     static void* oldFn_; \
 }; void* mock_module_##func::oldFn_ = nullptr;
@@ -553,8 +622,17 @@ struct mock_module_##func \
         GMOCK_ARG_(tn, 8, __VA_ARGS__) gmock_a8, \
         GMOCK_ARG_(tn, 9, __VA_ARGS__) gmock_a9) \
     { \
-        return mock_module_##func::instance().func( \
-            gmock_a1, gmock_a2, gmock_a3, gmock_a4, gmock_a5, gmock_a6, gmock_a7, gmock_a8, gmock_a9); \
+        if (gmock_win32::detail::lock) \
+        { \
+            return reinterpret_cast< decltype(&stub) >(mock_module_##func::oldFn_)( \
+                gmock_a1, gmock_a2, gmock_a3, gmock_a4, gmock_a5, gmock_a6, gmock_a7, gmock_a8, gmock_a9); \
+        } \
+        else \
+        { \
+            const gmock_win32::bypass_mocks blockMocks{ }; \
+            return instance().func( \
+                gmock_a1, gmock_a2, gmock_a3, gmock_a4, gmock_a5, gmock_a6, gmock_a7, gmock_a8, gmock_a9); \
+        } \
     } \
     static void* oldFn_; \
 }; void* mock_module_##func::oldFn_ = nullptr;
@@ -619,8 +697,17 @@ struct mock_module_##func \
         GMOCK_ARG_(tn, 9, __VA_ARGS__) gmock_a9, \
         GMOCK_ARG_(tn, 10, __VA_ARGS__) gmock_a10) \
     { \
-        return mock_module_##func::instance().func( \
-            gmock_a1, gmock_a2, gmock_a3, gmock_a4, gmock_a5, gmock_a6, gmock_a7, gmock_a8, gmock_a9, gmock_a10); \
+        if (gmock_win32::detail::lock) \
+        { \
+            return reinterpret_cast< decltype(&stub) >(mock_module_##func::oldFn_)( \
+                gmock_a1, gmock_a2, gmock_a3, gmock_a4, gmock_a5, gmock_a6, gmock_a7, gmock_a8, gmock_a9, gmock_a10); \
+        } \
+        else \
+        { \
+            const gmock_win32::bypass_mocks blockMocks{ }; \
+            return instance().func( \
+                gmock_a1, gmock_a2, gmock_a3, gmock_a4, gmock_a5, gmock_a6, gmock_a7, gmock_a8, gmock_a9, gmock_a10); \
+        } \
     } \
     static void* oldFn_; \
 }; void* mock_module_##func::oldFn_ = nullptr;
@@ -688,8 +775,17 @@ struct mock_module_##func \
         GMOCK_ARG_(tn, 10, __VA_ARGS__) gmock_a10, \
         GMOCK_ARG_(tn, 11, __VA_ARGS__) gmock_a11) \
     { \
-        return mock_module_##func::instance().func( \
-            gmock_a1, gmock_a2, gmock_a3, gmock_a4, gmock_a5, gmock_a6, gmock_a7, gmock_a8, gmock_a9, gmock_a10, gmock_a11); \
+        if (gmock_win32::detail::lock) \
+        { \
+            return reinterpret_cast< decltype(&stub) >(mock_module_##func::oldFn_)( \
+                gmock_a1, gmock_a2, gmock_a3, gmock_a4, gmock_a5, gmock_a6, gmock_a7, gmock_a8, gmock_a9, gmock_a10, gmock_a11); \
+        } \
+        else \
+        { \
+            const gmock_win32::bypass_mocks blockMocks{ }; \
+            return instance().func( \
+                gmock_a1, gmock_a2, gmock_a3, gmock_a4, gmock_a5, gmock_a6, gmock_a7, gmock_a8, gmock_a9, gmock_a10, gmock_a11); \
+        } \
     } \
     static void* oldFn_; \
 }; void* mock_module_##func::oldFn_ = nullptr;
@@ -760,8 +856,17 @@ struct mock_module_##func \
         GMOCK_ARG_(tn, 11, __VA_ARGS__) gmock_a11, \
         GMOCK_ARG_(tn, 12, __VA_ARGS__) gmock_a12) \
     { \
-        return mock_module_##func::instance().func( \
-            gmock_a1, gmock_a2, gmock_a3, gmock_a4, gmock_a5, gmock_a6, gmock_a7, gmock_a8, gmock_a9, gmock_a10, gmock_a11, gmock_a12); \
+        if (gmock_win32::detail::lock) \
+        { \
+            return reinterpret_cast< decltype(&stub) >(mock_module_##func::oldFn_)( \
+                gmock_a1, gmock_a2, gmock_a3, gmock_a4, gmock_a5, gmock_a6, gmock_a7, gmock_a8, gmock_a9, gmock_a10, gmock_a11, gmock_a12); \
+        } \
+        else \
+        { \
+            const gmock_win32::bypass_mocks blockMocks{ }; \
+            return instance().func( \
+                gmock_a1, gmock_a2, gmock_a3, gmock_a4, gmock_a5, gmock_a6, gmock_a7, gmock_a8, gmock_a9, gmock_a10, gmock_a11, gmock_a12); \
+        } \
     } \
     static void* oldFn_; \
 }; void* mock_module_##func::oldFn_ = nullptr;
@@ -835,8 +940,17 @@ struct mock_module_##func \
         GMOCK_ARG_(tn, 12, __VA_ARGS__) gmock_a12, \
         GMOCK_ARG_(tn, 13, __VA_ARGS__) gmock_a13) \
     { \
-        return mock_module_##func::instance().func( \
-            gmock_a1, gmock_a2, gmock_a3, gmock_a4, gmock_a5, gmock_a6, gmock_a7, gmock_a8, gmock_a9, gmock_a10, gmock_a11, gmock_a12, gmock_a13); \
+        if (gmock_win32::detail::lock) \
+        { \
+            return reinterpret_cast< decltype(&stub) >(mock_module_##func::oldFn_)( \
+                gmock_a1, gmock_a2, gmock_a3, gmock_a4, gmock_a5, gmock_a6, gmock_a7, gmock_a8, gmock_a9, gmock_a10, gmock_a11, gmock_a12, gmock_a13); \
+        } \
+        else \
+        { \
+            const gmock_win32::bypass_mocks blockMocks{ }; \
+            return instance().func( \
+                gmock_a1, gmock_a2, gmock_a3, gmock_a4, gmock_a5, gmock_a6, gmock_a7, gmock_a8, gmock_a9, gmock_a10, gmock_a11, gmock_a12, gmock_a13); \
+        } \
     } \
     static void* oldFn_; \
 }; void* mock_module_##func::oldFn_ = nullptr;
@@ -869,7 +983,7 @@ struct mock_module_##func \
         __pragma(optimize("", off))
 
 // Hidden from optimizer
-template <typename TFunc, typename TStub>
+template< typename TFunc, typename TStub >
 void patchModuleFunc_(void** mock_module_func_oldFn, TFunc func, TStub stub) { 
     if (!(*mock_module_func_oldFn)) 
         mockModule_patchModuleFunc( 
@@ -878,7 +992,8 @@ void patchModuleFunc_(void** mock_module_func_oldFn, TFunc func, TStub stub) {
             , mock_module_func_oldFn);
 }
 
-#define MOCK_CDECL_FUNC(r, m, ...) MOCK_MODULE_OVERLOAD(MOCK_MODULE_FUNC, MOCK_MODULE_NBARG(__VA_ARGS__)##__CDECL_CONV)##(m, r(__VA_ARGS__))
+#define MOCK_CDECL_FUNC(r, m, ...) \
+    MOCK_MODULE_OVERLOAD(MOCK_MODULE_FUNC, MOCK_MODULE_NBARG(__VA_ARGS__)##__CDECL_CONV)##(m, r(__VA_ARGS__))
 
 void mockModule_patchModuleFunc   (void*, void*, void**);
 void mockModule_restoreModuleFunc (void*, void*, void**);

--- a/include/gmock-win32.h
+++ b/include/gmock-win32.h
@@ -34,7 +34,6 @@ namespace detail {
 
     struct proxy_base
     {
-        proxy_base()  noexcept;
         ~proxy_base() noexcept;
     };
 
@@ -51,7 +50,7 @@ namespace detail {
     template< typename Reference >
     ref_proxy< Reference > make_proxy(Reference&& r) noexcept
     {
-        return ref_proxy< Reference >{ std::forward< decltype(r) >(r) };
+        return ref_proxy< Reference >{ std::forward< Reference >(r) };
     }
 
 } // namespace detail
@@ -862,21 +861,21 @@ struct mock_module_##func \
 #define MOCK_MODULE_FUNC(r, m, ...) MOCK_MODULE_OVERLOAD(MOCK_MODULE_FUNC, MOCK_MODULE_NBARG(__VA_ARGS__))##(m, r(__VA_ARGS__))
 
 #define MOCK_STDCALL_FUNC(r, m, ...) \
-	MOCK_MODULE_OVERLOAD(MOCK_MODULE_FUNC, MOCK_MODULE_NBARG(__VA_ARGS__)##_STDCALL_CONV)##(m, r(__VA_ARGS__)) \
-	__pragma(optimize("", on)) \
-	static void patchModuleFunc_##m() { \
-		::patchModuleFunc_( &mock_module_##m::oldFn_, &::m, &mock_module_##m::stub ); \
-	} \
-	__pragma(optimize("", off))
+    MOCK_MODULE_OVERLOAD(MOCK_MODULE_FUNC, MOCK_MODULE_NBARG(__VA_ARGS__)##_STDCALL_CONV)##(m, r(__VA_ARGS__)) \
+        __pragma(optimize("", on)) \
+        static void patchModuleFunc_##m() { \
+            ::patchModuleFunc_( &mock_module_##m::oldFn_, &::m, &mock_module_##m::stub ); \
+        } \
+        __pragma(optimize("", off))
 
 // Hidden from optimizer
 template <typename TFunc, typename TStub>
 void patchModuleFunc_(void** mock_module_func_oldFn, TFunc func, TStub stub) { 
-	if (!(*mock_module_func_oldFn)) 
-		mockModule_patchModuleFunc( 
-			func 
-			, reinterpret_cast< void* >( stub ) 
-			, mock_module_func_oldFn);
+    if (!(*mock_module_func_oldFn)) 
+        mockModule_patchModuleFunc( 
+            func 
+            , reinterpret_cast< void* >( stub ) 
+            , mock_module_func_oldFn);
 }
 
 #define MOCK_CDECL_FUNC(r, m, ...) MOCK_MODULE_OVERLOAD(MOCK_MODULE_FUNC, MOCK_MODULE_NBARG(__VA_ARGS__)##__CDECL_CONV)##(m, r(__VA_ARGS__))
@@ -885,14 +884,14 @@ void mockModule_patchModuleFunc   (void*, void*, void**);
 void mockModule_restoreModuleFunc (void*, void*, void**);
 
 #define EXPECT_MODULE_FUNC_CALL(func, ...) \
-	patchModuleFunc_##func( ); \
+    patchModuleFunc_##func( ); \
     ++gmock_win32::detail::lock; \
     static_cast< decltype(EXPECT_CALL(mock_module_##func::instance(), \
         func(__VA_ARGS__)))& >(gmock_win32::detail::make_proxy( \
             EXPECT_CALL(mock_module_##func::instance(), func(__VA_ARGS__))))
 
 #define ON_MODULE_FUNC_CALL(func, ...) \
-	patchModuleFunc_##func( ); \
+    patchModuleFunc_##func( ); \
     ++gmock_win32::detail::lock; \
     static_cast< decltype(ON_CALL(mock_module_##func::instance(), \
         func(__VA_ARGS__)))& >(gmock_win32::detail::make_proxy( \

--- a/include/gmock-win32.h
+++ b/include/gmock-win32.h
@@ -7,18 +7,63 @@
 
 #ifndef GMOCK_ARG_
 #define GMOCK_ARG_(tn, N, ...) \
-    tn ::testing::internal::Function<__VA_ARGS__>::template Arg<N-1>::type 
+    tn ::testing::internal::Function<__VA_ARGS__>::template Arg< N-1 >::type 
 #endif
 
 #ifndef GMOCK_MATCHER_
 #define GMOCK_MATCHER_(tn, N, ...) \
-    const ::testing::Matcher<GMOCK_ARG_(tn, N, __VA_ARGS__)>&
+    const ::testing::Matcher< GMOCK_ARG_(tn, N, __VA_ARGS__) >&
 #endif
 
 #ifndef GMOCK_MOCKER_
 #define GMOCK_MOCKER_(arity, constness, func) \
     GTEST_CONCAT_TOKEN_(gmock##constness##arity##_##func##_, __LINE__)
 #endif
+
+namespace gmock_win32 {
+
+    struct bypass_mocks final
+    {
+        bypass_mocks()  noexcept;
+        ~bypass_mocks() noexcept;
+    };
+
+namespace detail {
+
+    extern thread_local int lock;
+
+    struct proxy_base
+    {
+        proxy_base()  noexcept;
+        ~proxy_base() noexcept;
+    };
+
+    template< typename Reference >
+    struct ref_proxy final : proxy_base
+    {
+        explicit ref_proxy(Reference&& r) noexcept : ref_{ r } { }
+        operator Reference() const noexcept { return ref_; }
+
+    private:
+        Reference ref_;
+    };
+
+    template< typename Reference >
+    ref_proxy< Reference > make_proxy(Reference&& r) noexcept
+    {
+        return ref_proxy< Reference >{ std::forward< decltype(r) >(r) };
+    }
+
+} // namespace detail
+} // namespace gmock_win32
+
+#define BYPASS_MOCKS(expr) \
+    do \
+    { \
+        const gmock_win32::bypass_mocks blockMocks{ }; \
+        expr; \
+    } \
+    while (false);
 
 #define MOCK_MODULE_FUNC0_(tn, constness, ct, func, ...) \
 struct mock_module_##func \
@@ -43,7 +88,15 @@ struct mock_module_##func \
     } \
     static GMOCK_RESULT_(tn, __VA_ARGS__) ct stub() \
     { \
-        return mock_module_##func::instance().func(); \
+        if (gmock_win32::detail::lock) \
+        { \
+            return reinterpret_cast< decltype(&stub) >(mock_module_##func::oldFn_)(); \
+        } \
+        else \
+        { \
+            const gmock_win32::bypass_mocks blockMocks{ }; \
+            return instance().func(); \
+        } \
     } \
     static void* oldFn_; \
 }; void* mock_module_##func::oldFn_ = nullptr;
@@ -817,18 +870,24 @@ void mockModule_restoreModuleFunc (void*, void*, void**);
 #define EXPECT_MODULE_FUNC_CALL(func, ...) \
     if (!mock_module_##func::oldFn_) \
     { \
-        mockModule_patchModuleFunc(&func, reinterpret_cast< void* >( \
+        ::mockModule_patchModuleFunc(&func, reinterpret_cast< void* >( \
             &mock_module_##func::stub), &mock_module_##func::oldFn_); \
     } \
-    EXPECT_CALL(mock_module_##func::instance(), func(__VA_ARGS__))
+    ++gmock_win32::detail::lock; \
+    static_cast< decltype(EXPECT_CALL(mock_module_##func::instance(), \
+        func(__VA_ARGS__)))& >(gmock_win32::detail::make_proxy( \
+            EXPECT_CALL(mock_module_##func::instance(), func(__VA_ARGS__))))
 
 #define ON_MODULE_FUNC_CALL(func, ...) \
     if (!mock_module_##func::oldFn_) \
     { \
-        mockModule_patchModuleFunc(&func, reinterpret_cast< void* >( \
+        ::mockModule_patchModuleFunc(&func, reinterpret_cast< void* >( \
             &mock_module_##func::stub), &mock_module_##func::oldFn_); \
     } \
-    ON_CALL(mock_module_##func::instance(), func(__VA_ARGS__))
+    ++gmock_win32::detail::lock; \
+    static_cast< decltype(ON_CALL(mock_module_##func::instance(), \
+        func(__VA_ARGS__)))& >(gmock_win32::detail::make_proxy( \
+            ON_CALL(mock_module_##func::instance(), func(__VA_ARGS__))))
 
 #define REAL_MODULE_FUNC(func) \
     reinterpret_cast< decltype(&func) >(mock_module_##func::oldFn_)
@@ -837,7 +896,7 @@ void mockModule_restoreModuleFunc (void*, void*, void**);
     REAL_MODULE_FUNC(func)(__VA_ARGS__)
 
 #define VERIFY_AND_CLEAR_MODULE_FUNC_EXPECTATIONS(func) \
-    ::testing::Mock::VerifyAndClearExpectations(&mock_module_##func::instance())
+    ::testing::Mock::VerifyAndClearExpectations(&mock_module_##func::instance());
 
 #define RESTORE_MODULE_FUNC(func) \
-    mockModule_restoreModuleFunc(mock_module_##func::oldFn_, mock_module_##func::stub, &mock_module_##func::oldFn_)
+    ::mockModule_restoreModuleFunc(mock_module_##func::oldFn_, mock_module_##func::stub, &mock_module_##func::oldFn_)

--- a/src/gmock-win32.cpp
+++ b/src/gmock-win32.cpp
@@ -66,7 +66,7 @@ namespace {
         {
             DWORD oldProtect{ };
             if (::VirtualProtect(address, size, PAGE_WRITECOPY, &oldProtect))
-            {               
+            {
                 std::shared_ptr< void > finalAction(nullptr, [&](auto&&...) {
                     ::VirtualProtect(address, size, oldProtect, &oldProtect);
                 });
@@ -175,3 +175,38 @@ void mockModule_restoreModuleFunc(
     if (oldFunc)
         *oldFunc = nullptr;
 }
+
+namespace gmock_win32 {
+namespace detail {
+
+    thread_local int lock = 0;
+
+    void avoid_opt(const int& v)
+    {
+        wchar_t text[] = { (wchar_t)v, L'\0' };
+        ::GetWindowText(nullptr, text, 0);
+    }
+
+    proxy_base::proxy_base() noexcept
+    {
+        avoid_opt(lock);
+    }
+    
+    proxy_base::~proxy_base() noexcept
+    {
+        avoid_opt(--lock);
+    }
+
+} // namespace detail
+
+    bypass_mocks::bypass_mocks() noexcept
+    {
+        ++detail::lock;
+    }
+
+    bypass_mocks::~bypass_mocks() noexcept
+    {
+        --detail::lock;
+    }
+
+} // namespace gmock_win32

--- a/src/gmock-win32.cpp
+++ b/src/gmock-win32.cpp
@@ -212,9 +212,9 @@ namespace {
 void mockModule_patchModuleFunc(
     void* funcAddr, void* newFunc, void** oldFunc)
 {
-	if ( !g_bInit )
-		if ( !init( ) )
-	        throw std::runtime_error{ "failed to initialize patcher" };
+    if ( !g_bInit )
+        if ( !init( ) )
+            throw std::runtime_error{ "failed to initialize patcher" };
     if (FAILED(patchImportFunc(funcAddr, newFunc, oldFunc)))
         throw std::runtime_error{ "failed to patch module function" };
 }
@@ -222,8 +222,8 @@ void mockModule_patchModuleFunc(
 void mockModule_restoreModuleFunc(
     void* origFunc, void* stubFunc, void** oldFunc)
 {
-	if ( !g_bInit )
-		throw std::runtime_error{ "failed in initialization order" };
+    if ( !g_bInit )
+        throw std::runtime_error{ "failed in initialization order" };
     if (FAILED(restoreImportFunc(origFunc, stubFunc)))
         throw std::runtime_error{ "failed to restore module function" };
 
@@ -235,21 +235,10 @@ namespace gmock_win32 {
 namespace detail {
 
     thread_local int lock = 0;
-
-    void avoid_opt(const int& v)
-    {
-        wchar_t text[] = { (wchar_t)v, L'\0' };
-        ::GetWindowText(nullptr, text, 0);
-    }
-
-    proxy_base::proxy_base() noexcept
-    {
-        avoid_opt(lock);
-    }
     
     proxy_base::~proxy_base() noexcept
     {
-        avoid_opt(--lock);
+        --lock;
     }
 
 } // namespace detail

--- a/src/gmock-win32.cpp
+++ b/src/gmock-win32.cpp
@@ -40,33 +40,36 @@ namespace {
 	pfnImageDirectoryEntryToDataEx_t g_pfnImageDirectoryEntryToDataEx = nullptr;
 
 	static bool g_bInit = false;
-	bool init() {
+	bool init()
+    {
 		HMODULE module;
-		module = LoadLibraryA( "kernel32.dll" );
+		module = ::LoadLibraryA( "kernel32.dll" );
 		if ( !module ) 
 			return false;
-		g_pfnGetLastError = (pfnGetLastError_t)GetProcAddress( module, "GetLastError" );
+
+		g_pfnGetLastError = (pfnGetLastError_t)::GetProcAddress( module, "GetLastError" );
 		if ( !g_pfnGetLastError ) 
 			return false;
-		g_pfnGetCurrentProcess = (pfnGetCurrentProcess_t)GetProcAddress( module, "GetCurrentProcess" );
+		g_pfnGetCurrentProcess = (pfnGetCurrentProcess_t)::GetProcAddress( module, "GetCurrentProcess" );
 		if ( !g_pfnGetCurrentProcess ) 
 			return false;
-		g_pfnWriteProcessMemory = (pfnWriteProcessMemory_t)GetProcAddress( module, "WriteProcessMemory" );
+		g_pfnWriteProcessMemory = (pfnWriteProcessMemory_t)::GetProcAddress( module, "WriteProcessMemory" );
 		if ( !g_pfnWriteProcessMemory ) 
 			return false;
-		g_pfnVirtualProtect = (pfnVirtualProtect_t)GetProcAddress( module, "VirtualProtect" );
+		g_pfnVirtualProtect = (pfnVirtualProtect_t)::GetProcAddress( module, "VirtualProtect" );
 		if ( !g_pfnVirtualProtect ) 
 			return false;
 		// Doesnt matter wchar_t or char, GetModuleHandleW or GetModuleHandleA
-		g_pfnGetModuleHandleA = (pfnGetModuleHandleA_t)GetProcAddress( module, "GetModuleHandleA" );
+		g_pfnGetModuleHandleA = (pfnGetModuleHandleA_t)::GetProcAddress( module, "GetModuleHandleA" );
 		if ( !g_pfnGetModuleHandleA ) 
 			return false;
-		module = LoadLibraryA( "dbghelp.dll" );
+		module = ::LoadLibraryA( "dbghelp.dll" );
 		if ( !module ) 
 			return false;
-		g_pfnImageDirectoryEntryToDataEx = (pfnImageDirectoryEntryToDataEx_t)GetProcAddress( module, "ImageDirectoryEntryToDataEx" );
+		g_pfnImageDirectoryEntryToDataEx = (pfnImageDirectoryEntryToDataEx_t)::GetProcAddress( module, "ImageDirectoryEntryToDataEx" );
 		if ( !g_pfnImageDirectoryEntryToDataEx ) 
 			return false;
+
 		g_bInit = true;
 		return true;
 	}
@@ -215,6 +218,7 @@ void mockModule_patchModuleFunc(
     if ( !g_bInit )
         if ( !init( ) )
             throw std::runtime_error{ "failed to initialize patcher" };
+
     if (FAILED(patchImportFunc(funcAddr, newFunc, oldFunc)))
         throw std::runtime_error{ "failed to patch module function" };
 }
@@ -224,6 +228,7 @@ void mockModule_restoreModuleFunc(
 {
     if ( !g_bInit )
         throw std::runtime_error{ "failed in initialization order" };
+
     if (FAILED(restoreImportFunc(origFunc, stubFunc)))
         throw std::runtime_error{ "failed to restore module function" };
 


### PR DESCRIPTION
Sample where the fix was tested:

```cpp
#include <gmock/gmock.h>
#include <gmock-win32.h>

MOCK_STDCALL_FUNC(DWORD, GetCurrentThreadId);

TEST(GetCurrentThreadIdTest, BaseTest)
{
    ON_MODULE_FUNC_CALL(GetCurrentThreadId).WillByDefault(testing::Return(42U));
    EXPECT_MODULE_FUNC_CALL(GetCurrentThreadId).Times(2);

    const auto tid1 = ::GetCurrentThreadId();
    const auto tid2 = ::GetCurrentThreadId();

    BYPASS_MOCKS(EXPECT_EQ(tid1, 42U));
    BYPASS_MOCKS(EXPECT_EQ(tid2, 42U));

    RESTORE_MODULE_FUNC(GetCurrentThreadId);
    VERIFY_AND_CLEAR_MODULE_FUNC_EXPECTATIONS(GetCurrentThreadId);
}

int main(int argc, char* argv[])
{
    testing::InitGoogleTest(&argc, argv);
    return RUN_ALL_TESTS();
}
```

Env:
- GTest: googletest-1.13.0
- Toolchains: MSVC 2015 v140; MSVC 2022 v143 /std:c++17
- Platform: x86

---
Not solved problems:
- We need to avoid optimizations for lock, see `avoid_opt` test code
- The `RESTORE_MODULE_FUNC` call is required before expectations checks
- Current implementation made only for MOCK_MODULE_FUNC0_
---
To close the issue, the merging of this PR is also required:
https://github.com/smalti/gmock-win32/pull/7
