### PR TITLE
There was a problem with AppCompat in earlier versions. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,7 +261,7 @@ Here are some examples of library usage: [gmock-win32-sample](https://github.com
 ## Version 1.1.0 (29 August 2023)
 - Added support for functions with 9-13 parameters
 - Added `REAL_MODULE_FUNC` macro
-- Fixed problem with Windows ApiSet DLL functions redirection
+- Fixed problem with Windows ApiSet DLL functions redirection (AppCompat via Shimm DLL)
 
 ## Old versions:
 


### PR DESCRIPTION
This is for search engines, SEO and traffic only.

Before version '1.1.0' of `gmock-win32` i had a problem in "CI":
System calls, such as `DestroyWindow` pointed to `apphelp.dll` when the program was __first__ launched. On Windows Server 2022 (GitHub Action) and local Windows 10. Everything did not work because the library core was looking for a match to the name of the import dll, it was not `apphelp.dll`.
Maybe people had a similar problem in earlier versions of the library. Or they will accidentally come here by searching for the AppCompat topic.
For example about AppCompat theme: [SO appcompat-shims](https://stackoverflow.com/questions/1711665/windows-how-to-create-custom-appcompat-shims-application-fixes)

It seems sufficient to add two keywords at the right place in the documentation. I hope it doesn't look like trash.