### PR TITLE
Added macro expansion support

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,10 +64,14 @@ ON_MODULE_FUNC_CALL(GetCurrentProcessId).WillByDefault(Return(42));
 ON_MODULE_FUNC_CALL(GetProcessIdOfThread, Eq(HANDLE(42))).WillByDefault(Return(1));
 ```
 
-#### 4. To validate and clear expectations after tests use the `VERIFY_AND_CLEAR_MODULE_FUNC_EXPECTATIONS` macro (usually used for multiple tests with different expectations and can be executed as part of the test tear-down logic)
+#### 4. To validate and clear expectations after tests use the `VERIFY_AND_CLEAR_MODULE_FUNC` or `VERIFY_AND_CLEAR_MODULE_FUNC_EXPECTATIONS` macro (usually used for multiple tests with different expectations and can be executed as part of the test tear-down logic)
 
 ```cpp
+// Verifies and removes the expectations
 VERIFY_AND_CLEAR_MODULE_FUNC_EXPECTATIONS(GetCurrentProcessId);
+
+// Verifies and removes the expectations and removes the default actions set by ON_CALL
+VERIFY_AND_CLEAR_MODULE_FUNC(GetProcessIdOfThread);
 ```
 
 #### 5. Use the `RESTORE_MODULE_FUNC` macro to restore the original module function and remove the IAT patch after all tests finished
@@ -130,7 +134,8 @@ After mock expectations set:
   GetCurrentProcessId:  42
   GetProcessIdOfThread: 1
 ```
-Here are some additional examples of library usage: [gmock-win32-sample](https://github.com/smalti/gmock-win32-sample)
+
+### Here are some additional examples of library usage: [gmock-win32-sample](https://github.com/smalti/gmock-win32-sample)
 
 # Advanced Topics
 

--- a/src/gmock-win32.cpp
+++ b/src/gmock-win32.cpp
@@ -188,6 +188,7 @@ namespace utils {
             {               
                 std::shared_ptr< void > finalAction(nullptr, [&](auto&&...)
                 {
+                    // Ignore all function failures
                     core->pfn_FlushInstructionCache(processHandle, address, size);
                     core->pfn_VirtualProtect(address, size, oldProtect, &oldProtect);
                 });


### PR DESCRIPTION
#### 1. Added new macro: `VERIFY_AND_CLEAR_MODULE_FUNC`

#### 2. Added macro expansion support for:
- RESTORE_MODULE_FUNC
- VERIFY_AND_CLEAR_MODULE_FUNC_EXPECTATIONS
- VERIFY_AND_CLEAR_MODULE_FUNC
- REAL_MODULE_FUNC
- INVOKE_REAL_MODULE_FUNC

#### 3. Renamed `patch_module_func_` to `patch_module_func_non_optimized` and moved it to the private namespace: `gmock_win32::detail`