### PR TITLE
Used not Wow64 compatible type PIMAGE_THUNK_DATA32

### DIFF
--- a/src/gmock-win32.cpp
+++ b/src/gmock-win32.cpp
@@ -209,7 +209,7 @@ namespace utils {
         }
     }
 
-    LPVOID* thunkProc(const PIMAGE_THUNK_DATA32 data) noexcept
+    LPVOID* thunkProc(const PIMAGE_THUNK_DATA data) noexcept
     {
         return reinterpret_cast< LPVOID* >(&data->u1.Function);
     }


### PR DESCRIPTION
Found in process of developing CI, in clang for x64.
Got error:
```
../src/gmock-win32.cpp(238): error C2664: 'LPVOID *anonymous-namespace'::thunkProc(const PIMAGE_THUNK_DATA32) noexcept': cannot convert argument 1 from 'Type *' to 'const PIMAGE_THUNK_DATA32'
        with
        [
            Type=IMAGE_THUNK_DATA
        ]
```