### PR TITLE
Add gcc (msys2) support

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -123,3 +123,24 @@ jobs:
         if: ${{ failure( ) }}
         run: | # pwsh
           echo "tmp echo"
+
+  test-msys2:
+    runs-on: windows-latest
+    defaults:
+      run:
+        working-directory: ${{ env.strDirTests }}
+        shell: msys2 {0}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: msys2/setup-msys2@v2
+        with:
+          pacboy: >-
+            toolchain:p
+            gtest:p
+
+      - name: Build and run tests
+        run: |
+          g++ -std=c++17 -o test *.cpp ../src/*.cpp -I../include -lgtest -lgmock -lgdi32
+          ./test

--- a/README.md
+++ b/README.md
@@ -259,6 +259,7 @@ int main(int argc, char* argv[])
 * MSVC >= 2019 (v142)
 * Clang >= 12.0.0
 * Windows Client >= 10
+* GCC (MSYS2) >= 14.1
 
 # Tested with GTest
 

--- a/include/gmock-win32.h
+++ b/include/gmock-win32.h
@@ -1,5 +1,7 @@
 #pragma once
 #include <utility>
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
 
 #ifndef GMOCK_RESULT_
 #define GMOCK_RESULT_(tn, ...) \

--- a/include/gmock-win32.h
+++ b/include/gmock-win32.h
@@ -97,7 +97,7 @@ namespace detail {
     {
         if (!(*old_fn))
             patch_module_func(
-                func_name, func, reinterpret_cast< void* >(stub), old_fn);
+                func_name, reinterpret_cast< void* >(func), reinterpret_cast< void* >(stub), old_fn);
     }
 
 } // namespace detail
@@ -1027,7 +1027,7 @@ struct mock_module_##func : \
 
 #define RESTORE_MODULE_FUNC_IMPL_(func) \
     gmock_win32::detail::restore_module_func( \
-        #func, *mock_module_##func::pp_old_fn(), mock_module_##func::stub, mock_module_##func::pp_old_fn())
+        #func, *mock_module_##func::pp_old_fn(), reinterpret_cast<void*>(mock_module_##func::stub), mock_module_##func::pp_old_fn())
 
 #define RESTORE_MODULE_FUNC(func) \
     RESTORE_MODULE_FUNC_IMPL_(func)

--- a/include/gmock-win32.h
+++ b/include/gmock-win32.h
@@ -3,6 +3,16 @@
 #include <gtest/gtest.h>
 #include <gmock/gmock.h>
 
+#ifdef _MSC_VER
+#define PRAGMA_UNOPTIMIZE_ON __pragma(optimize("", on))
+#define PRAGMA_UNOPTIMIZE_OFF __pragma(optimize("", off))
+#define ATTRIBUTE_UNOPTIMIZE
+#else
+#define PRAGMA_UNOPTIMIZE_ON
+#define PRAGMA_UNOPTIMIZE_OFF
+#define ATTRIBUTE_UNOPTIMIZE __attribute__((optimize("O0")))
+#endif
+
 #ifndef GMOCK_RESULT_
 #define GMOCK_RESULT_(tn, ...) \
     tn ::testing::internal::Function<__VA_ARGS__>::Result
@@ -949,12 +959,12 @@ struct mock_module_##func : \
 #define MOCK_MODULE_FUNC_OVERLOAD_(name, ...) MOCK_MODULE_UNITE_(MOCK_MODULE_OVERLOAD_(name, MOCK_MODULE_NBARG_(__VA_ARGS__)), (__VA_ARGS__))
 
 #define MOCK_MODULE_AVOID_OPT_(m) \
-    __pragma(optimize("", on)) \
-    static void patch_module_func_##m() { \
+    PRAGMA_UNOPTIMIZE_ON \
+    static void ATTRIBUTE_UNOPTIMIZE patch_module_func_##m() { \
         gmock_win32::detail::patch_module_func_non_optimized( \
             #m, mock_module_##m::pp_old_fn(), &::m, &mock_module_##m::stub); \
     } \
-    __pragma(optimize("", off))
+    PRAGMA_UNOPTIMIZE_OFF
 
 // helper to paste m and args from __VA_ARGS__ below
 #define MOCK_MODULE_FUNC_(r, m, conv, count_args, ...) \

--- a/src/gmock-win32.cpp
+++ b/src/gmock-win32.cpp
@@ -11,6 +11,11 @@
 #include <string>
 #include <stdexcept>
 
+#ifndef _MSC_VER
+#define __try try
+#define __except(...) catch(...)
+#endif
+
 #pragma comment(lib, "dbghelp.lib")
 
 #define THROW_HRESULT(hr, text)                     \

--- a/src/gmock-win32.cpp
+++ b/src/gmock-win32.cpp
@@ -2,10 +2,15 @@
 
 #include <windows.h>
 
+#ifdef _MSC_VER
 #pragma warning(push)
 #pragma warning(disable: 4091)
 #include <dbghelp.h>
 #pragma warning(pop)
+#pragma comment(lib, "dbghelp.lib")
+#else
+#include <dbghelp.h>
+#endif
 
 #include <memory>
 #include <string>
@@ -15,8 +20,6 @@
 #define __try try
 #define __except(...) catch(...)
 #endif
-
-#pragma comment(lib, "dbghelp.lib")
 
 #define THROW_HRESULT(hr, text)                     \
     throw std::runtime_error{                       \
@@ -57,8 +60,10 @@ namespace module {
 
 namespace utils {
 
+#ifdef _MSC_VER
 #pragma warning(push)
 #pragma warning(disable: 4702)
+#endif
     UniqueHMODULE loadModule(const wchar_t* moduleName)
     {
         if (const auto hmodule = ::LoadLibraryW(moduleName))
@@ -68,7 +73,9 @@ namespace utils {
 
         return UniqueHMODULE{ nullptr, { } };
     }
+#ifdef _MSC_VER
 #pragma warning(pop)
+#endif
 
     int strcmp(const char* s1, const char* s2) noexcept
     {

--- a/tests/from0ToMax.cpp
+++ b/tests/from0ToMax.cpp
@@ -88,8 +88,8 @@ TEST(from0ToMax, args3) {
 }
 TEST(from0ToMax, args4) {
 	auto pAcl = reinterpret_cast< PACL >( INVALID_HANDLE_VALUE );
-	auto dwAceRevision = reinterpret_cast< DWORD >( INVALID_HANDLE_VALUE );
-	auto AccessMask = reinterpret_cast< DWORD >( INVALID_HANDLE_VALUE );
+	auto dwAceRevision = static_cast< DWORD >( reinterpret_cast< ULONG_PTR >( INVALID_HANDLE_VALUE ) );
+	auto AccessMask = static_cast< DWORD >( reinterpret_cast< ULONG_PTR >( INVALID_HANDLE_VALUE ) );
 	auto pSid = reinterpret_cast< PSID >( INVALID_HANDLE_VALUE );
 	EXPECT_MODULE_FUNC_CALL( AddAccessAllowedAce, 
 			pAcl
@@ -106,9 +106,9 @@ TEST(from0ToMax, args4) {
 }
 TEST(from0ToMax, args5) {
 	auto pAcl = reinterpret_cast< PACL >( INVALID_HANDLE_VALUE );
-	auto dwAceRevision = reinterpret_cast< DWORD >( INVALID_HANDLE_VALUE );
-	auto AceFlags = reinterpret_cast< DWORD >( INVALID_HANDLE_VALUE );
-	auto AccessMask = reinterpret_cast< DWORD >( INVALID_HANDLE_VALUE );
+	auto dwAceRevision = static_cast< DWORD >( reinterpret_cast< ULONG_PTR >( INVALID_HANDLE_VALUE ) );
+	auto AceFlags = static_cast< DWORD >( reinterpret_cast< ULONG_PTR >( INVALID_HANDLE_VALUE ) );
+	auto AccessMask = static_cast< DWORD >( reinterpret_cast< ULONG_PTR >( INVALID_HANDLE_VALUE ) );
 	auto pSid = reinterpret_cast< PSID >( INVALID_HANDLE_VALUE );
 	EXPECT_MODULE_FUNC_CALL( AddAccessAllowedAceEx, 
 			pAcl
@@ -127,11 +127,11 @@ TEST(from0ToMax, args5) {
 }
 TEST(from0ToMax, args6) {
 	auto pAcl = reinterpret_cast< PACL >( INVALID_HANDLE_VALUE );
-	auto dwAceRevision = reinterpret_cast< DWORD >( INVALID_HANDLE_VALUE );
-	auto dwAccessMask = reinterpret_cast< DWORD >( INVALID_HANDLE_VALUE );
+	auto dwAceRevision = static_cast< DWORD >( reinterpret_cast< ULONG_PTR >( INVALID_HANDLE_VALUE ) );
+	auto dwAccessMask = static_cast< DWORD >( reinterpret_cast< ULONG_PTR >( INVALID_HANDLE_VALUE ) );
 	auto pSid = reinterpret_cast< PSID >( INVALID_HANDLE_VALUE );
-	auto bAuditSuccess = reinterpret_cast< BOOL >( INVALID_HANDLE_VALUE );
-	auto bAuditFailure = reinterpret_cast< BOOL >( INVALID_HANDLE_VALUE );
+	auto bAuditSuccess = static_cast< BOOL >( reinterpret_cast< ULONG_PTR >( INVALID_HANDLE_VALUE ) );
+	auto bAuditFailure = static_cast< BOOL >( reinterpret_cast< ULONG_PTR >( INVALID_HANDLE_VALUE ) );
 	EXPECT_MODULE_FUNC_CALL( AddAuditAccessAce, 
 			pAcl
 			, dwAceRevision
@@ -151,9 +151,9 @@ TEST(from0ToMax, args6) {
 }
 TEST(from0ToMax, args7) {
 	auto pAcl = reinterpret_cast< PACL >( INVALID_HANDLE_VALUE );
-	auto dwAceRevision = reinterpret_cast< DWORD >( INVALID_HANDLE_VALUE );
-	auto AceFlags = reinterpret_cast< DWORD >( INVALID_HANDLE_VALUE );
-	auto AccessMask = reinterpret_cast< DWORD >( INVALID_HANDLE_VALUE );
+	auto dwAceRevision = static_cast< DWORD >( reinterpret_cast< ULONG_PTR >( INVALID_HANDLE_VALUE ) );
+	auto AceFlags = static_cast< DWORD >( reinterpret_cast< ULONG_PTR >( INVALID_HANDLE_VALUE ) );
+	auto AccessMask = static_cast< DWORD >( reinterpret_cast< ULONG_PTR >( INVALID_HANDLE_VALUE ) );
 	auto ObjectTypeGuid = reinterpret_cast< GUID* >( INVALID_HANDLE_VALUE );
 	auto InheritedObjectTypeGuid = reinterpret_cast< GUID* >( INVALID_HANDLE_VALUE );
 	auto pSid = reinterpret_cast< PSID >( INVALID_HANDLE_VALUE );
@@ -179,7 +179,7 @@ TEST(from0ToMax, args7) {
 TEST(from0ToMax, args8) {
 	auto pSecurityDescriptor = reinterpret_cast< PSECURITY_DESCRIPTOR >( INVALID_HANDLE_VALUE );
 	auto ClientToken = reinterpret_cast< HANDLE >( INVALID_HANDLE_VALUE );
-	auto DesiredAccess = reinterpret_cast< DWORD >( INVALID_HANDLE_VALUE );
+	auto DesiredAccess = static_cast< DWORD >( reinterpret_cast< ULONG_PTR >( INVALID_HANDLE_VALUE ) );
 	auto GenericMapping = reinterpret_cast< PGENERIC_MAPPING >( INVALID_HANDLE_VALUE );
 	auto PrivilegeSet = reinterpret_cast< PPRIVILEGE_SET >( INVALID_HANDLE_VALUE );
 	auto PrivilegeSetLength = reinterpret_cast< LPDWORD >( INVALID_HANDLE_VALUE );
@@ -208,14 +208,14 @@ TEST(from0ToMax, args8) {
 }
 TEST(from0ToMax, args9) {
 	auto pAcl = reinterpret_cast< PACL >( INVALID_HANDLE_VALUE );
-	auto dwAceRevision = reinterpret_cast< DWORD >( INVALID_HANDLE_VALUE );
-	auto AceFlags = reinterpret_cast< DWORD >( INVALID_HANDLE_VALUE );
-	auto AccessMask = reinterpret_cast< DWORD >( INVALID_HANDLE_VALUE );
+	auto dwAceRevision = static_cast< DWORD >( reinterpret_cast< ULONG_PTR >( INVALID_HANDLE_VALUE ) );
+	auto AceFlags = static_cast< DWORD >( reinterpret_cast< ULONG_PTR >( INVALID_HANDLE_VALUE ) );
+	auto AccessMask = static_cast< DWORD >( reinterpret_cast< ULONG_PTR >( INVALID_HANDLE_VALUE ) );
 	auto ObjectTypeGuid = reinterpret_cast< GUID* >( INVALID_HANDLE_VALUE );
 	auto InheritedObjectTypeGuid = reinterpret_cast< GUID* >( INVALID_HANDLE_VALUE );
 	auto pSid = reinterpret_cast< PSID >( INVALID_HANDLE_VALUE );
-	auto bAuditSuccess = reinterpret_cast< BOOL >( INVALID_HANDLE_VALUE );
-	auto bAuditFailure = reinterpret_cast< BOOL >( INVALID_HANDLE_VALUE );
+	auto bAuditSuccess = static_cast< BOOL >( reinterpret_cast< ULONG_PTR >( INVALID_HANDLE_VALUE ) );
+	auto bAuditFailure = static_cast< BOOL >( reinterpret_cast< ULONG_PTR >( INVALID_HANDLE_VALUE ) );
 	EXPECT_MODULE_FUNC_CALL( AddAuditAccessObjectAce, 
 			pAcl
 			, dwAceRevision
@@ -241,11 +241,11 @@ TEST(from0ToMax, args9) {
 }
 TEST(from0ToMax, args10) {
 	auto lpFileName = reinterpret_cast< LPCSTR >( INVALID_HANDLE_VALUE );
-	auto dwDesiredAccess = reinterpret_cast< DWORD >( INVALID_HANDLE_VALUE );
-	auto dwShareMode = reinterpret_cast< DWORD >( INVALID_HANDLE_VALUE );
+	auto dwDesiredAccess = static_cast< DWORD >( reinterpret_cast< ULONG_PTR >( INVALID_HANDLE_VALUE ) );
+	auto dwShareMode = static_cast< DWORD >( reinterpret_cast< ULONG_PTR >( INVALID_HANDLE_VALUE ) );
 	auto lpSecurityAttributes = reinterpret_cast< LPSECURITY_ATTRIBUTES >( INVALID_HANDLE_VALUE );
-	auto dwCreationDisposition = reinterpret_cast< DWORD >( INVALID_HANDLE_VALUE );
-	auto dwFlagsAndAttributes = reinterpret_cast< DWORD >( INVALID_HANDLE_VALUE );
+	auto dwCreationDisposition = static_cast< DWORD >( reinterpret_cast< ULONG_PTR >( INVALID_HANDLE_VALUE ) );
+	auto dwFlagsAndAttributes = static_cast< DWORD >( reinterpret_cast< ULONG_PTR >( INVALID_HANDLE_VALUE ) );
 	auto hTemplateFile = reinterpret_cast< HANDLE >( INVALID_HANDLE_VALUE );
 	auto hTransaction = reinterpret_cast< HANDLE >( INVALID_HANDLE_VALUE );
 	auto pusMiniVersion = reinterpret_cast< PUSHORT >( INVALID_HANDLE_VALUE );
@@ -279,9 +279,9 @@ TEST(from0ToMax, args11) {
 	auto pSecurityDescriptor = reinterpret_cast< PSECURITY_DESCRIPTOR >( INVALID_HANDLE_VALUE );
 	auto PrincipalSelfSid = reinterpret_cast< PSID >( INVALID_HANDLE_VALUE );
 	auto ClientToken = reinterpret_cast< HANDLE >( INVALID_HANDLE_VALUE );
-	auto DesiredAccess = reinterpret_cast< DWORD >( INVALID_HANDLE_VALUE );
+	auto DesiredAccess = static_cast< DWORD >( reinterpret_cast< ULONG_PTR >( INVALID_HANDLE_VALUE ) );
 	auto ObjectTypeList = reinterpret_cast< POBJECT_TYPE_LIST >( INVALID_HANDLE_VALUE );
-	auto ObjectTypeListLength = reinterpret_cast< DWORD >( INVALID_HANDLE_VALUE );
+	auto ObjectTypeListLength = static_cast< DWORD >( reinterpret_cast< ULONG_PTR >( INVALID_HANDLE_VALUE ) );
 	auto GenericMapping = reinterpret_cast< PGENERIC_MAPPING >( INVALID_HANDLE_VALUE );
 	auto PrivilegeSet = reinterpret_cast< PPRIVILEGE_SET >( INVALID_HANDLE_VALUE );
 	auto PrivilegeSetLength = reinterpret_cast< LPDWORD >( INVALID_HANDLE_VALUE );
@@ -321,11 +321,11 @@ TEST(from0ToMax, args12) {
 	auto ObjectName = reinterpret_cast< LPWSTR >( INVALID_HANDLE_VALUE );
 	auto pSecurityDescriptor = reinterpret_cast< PSECURITY_DESCRIPTOR >( INVALID_HANDLE_VALUE );
 	auto ClientToken = reinterpret_cast< HANDLE >( INVALID_HANDLE_VALUE );
-	auto DesiredAccess = reinterpret_cast< DWORD >( INVALID_HANDLE_VALUE );
-	auto GrantedAccess = reinterpret_cast< DWORD >( INVALID_HANDLE_VALUE );
+	auto DesiredAccess = static_cast< DWORD >( reinterpret_cast< ULONG_PTR >( INVALID_HANDLE_VALUE ) );
+	auto GrantedAccess = static_cast< DWORD >( reinterpret_cast< ULONG_PTR >( INVALID_HANDLE_VALUE ) );
 	auto Privileges = reinterpret_cast< PPRIVILEGE_SET >( INVALID_HANDLE_VALUE );
-	auto ObjectCreation = reinterpret_cast< BOOL >( INVALID_HANDLE_VALUE );
-	auto AccessGranted = reinterpret_cast< BOOL >( INVALID_HANDLE_VALUE );
+	auto ObjectCreation = static_cast< BOOL >( reinterpret_cast< ULONG_PTR >( INVALID_HANDLE_VALUE ) );
+	auto AccessGranted = static_cast< BOOL >( reinterpret_cast< ULONG_PTR >( INVALID_HANDLE_VALUE ) );
 	auto GenerateOnClose = reinterpret_cast< LPBOOL >( INVALID_HANDLE_VALUE );
 	EXPECT_MODULE_FUNC_CALL( ObjectOpenAuditAlarmW, 
 			SubsystemName
@@ -360,10 +360,10 @@ TEST(from0ToMax, args13) {
 	auto hSCManager = reinterpret_cast< SC_HANDLE >( INVALID_HANDLE_VALUE );
 	auto lpServiceName = reinterpret_cast< LPCSTR >( INVALID_HANDLE_VALUE );
 	auto lpDisplayName = reinterpret_cast< LPCSTR >( INVALID_HANDLE_VALUE );
-	auto dwDesiredAccess = reinterpret_cast< DWORD >( INVALID_HANDLE_VALUE );
-	auto dwServiceType = reinterpret_cast< DWORD >( INVALID_HANDLE_VALUE );
-	auto dwStartType = reinterpret_cast< DWORD >( INVALID_HANDLE_VALUE );
-	auto dwErrorControl = reinterpret_cast< DWORD >( INVALID_HANDLE_VALUE );
+	auto dwDesiredAccess = static_cast< DWORD >( reinterpret_cast< ULONG_PTR >( INVALID_HANDLE_VALUE ) );
+	auto dwServiceType = static_cast< DWORD >( reinterpret_cast< ULONG_PTR >( INVALID_HANDLE_VALUE ) );
+	auto dwStartType = static_cast< DWORD >( reinterpret_cast< ULONG_PTR >( INVALID_HANDLE_VALUE ) );
+	auto dwErrorControl = static_cast< DWORD >( reinterpret_cast< ULONG_PTR >( INVALID_HANDLE_VALUE ) );
 	auto lpBinaryPathName = reinterpret_cast< LPCSTR >( INVALID_HANDLE_VALUE );
 	auto lpLoadOrderGroup = reinterpret_cast< LPCSTR >( INVALID_HANDLE_VALUE );
 	auto lpdwTagId = reinterpret_cast< LPDWORD >( INVALID_HANDLE_VALUE );
@@ -402,19 +402,19 @@ TEST(from0ToMax, args13) {
 		);
 }
 //TEST(from0ToMax, args14) {
-//	auto cHeight = reinterpret_cast< int >( INVALID_HANDLE_VALUE );
-//	auto cWidth = reinterpret_cast< int >( INVALID_HANDLE_VALUE );
-//	auto cEscapement = reinterpret_cast< int >( INVALID_HANDLE_VALUE );
-//	auto cOrientation = reinterpret_cast< int >( INVALID_HANDLE_VALUE );
-//	auto cWeight = reinterpret_cast< int >( INVALID_HANDLE_VALUE );
-//	auto bItalic = reinterpret_cast< DWORD >( INVALID_HANDLE_VALUE );
-//	auto bUnderline = reinterpret_cast< DWORD >( INVALID_HANDLE_VALUE );
-//	auto bStrikeOut = reinterpret_cast< DWORD >( INVALID_HANDLE_VALUE );
-//	auto iCharSet = reinterpret_cast< DWORD >( INVALID_HANDLE_VALUE );
-//	auto iOutPrecision = reinterpret_cast< DWORD >( INVALID_HANDLE_VALUE );
-//	auto iClipPrecision = reinterpret_cast< DWORD >( INVALID_HANDLE_VALUE );
-//	auto iQuality = reinterpret_cast< DWORD >( INVALID_HANDLE_VALUE );
-//	auto iPitchAndFamily = reinterpret_cast< DWORD >( INVALID_HANDLE_VALUE );
+//	auto cHeight = static_cast< int >( reinterpret_cast< ULONG_PTR >( INVALID_HANDLE_VALUE ) );
+//	auto cWidth = static_cast< int >( reinterpret_cast< ULONG_PTR >( INVALID_HANDLE_VALUE ) );
+//	auto cEscapement = static_cast< int >( reinterpret_cast< ULONG_PTR >( INVALID_HANDLE_VALUE ) );
+//	auto cOrientation = static_cast< int >( reinterpret_cast< ULONG_PTR >( INVALID_HANDLE_VALUE ) );
+//	auto cWeight = static_cast< int >( reinterpret_cast< ULONG_PTR >( INVALID_HANDLE_VALUE ) );
+//	auto bItalic = static_cast< DWORD >( reinterpret_cast< ULONG_PTR >( INVALID_HANDLE_VALUE ) );
+//	auto bUnderline = static_cast< DWORD >( reinterpret_cast< ULONG_PTR >( INVALID_HANDLE_VALUE ) );
+//	auto bStrikeOut = static_cast< DWORD >( reinterpret_cast< ULONG_PTR >( INVALID_HANDLE_VALUE ) );
+//	auto iCharSet = static_cast< DWORD >( reinterpret_cast< ULONG_PTR >( INVALID_HANDLE_VALUE ) );
+//	auto iOutPrecision = static_cast< DWORD >( reinterpret_cast< ULONG_PTR >( INVALID_HANDLE_VALUE ) );
+//	auto iClipPrecision = static_cast< DWORD >( reinterpret_cast< ULONG_PTR >( INVALID_HANDLE_VALUE ) );
+//	auto iQuality = static_cast< DWORD >( reinterpret_cast< ULONG_PTR >( INVALID_HANDLE_VALUE ) );
+//	auto iPitchAndFamily = static_cast< DWORD >( reinterpret_cast< ULONG_PTR >( INVALID_HANDLE_VALUE ) );
 //	auto pszFaceName = reinterpret_cast< LPCSTR >( INVALID_HANDLE_VALUE );
 //	EXPECT_MODULE_FUNC_CALL( CreateFontA, 
 //			cHeight


### PR DESCRIPTION
Closes #40 

* define __try, __except as try, catch for non-msvc; I am not sure that would actually works, but it compiles and the happy path works.
* use defines for "unoptimize"
* reinterpret cast for function ptr -> void*
* puts a bunch of `#pragma`  behind ifdefs
* adds CI for Msys2 with MINGW64
* replace some problematic casts in tests
    *  `INVALID_HANDLE_VALUE` is a 64bit pointer and `DWORD` is 32bit, so we need to do pointer -> integer and then integer -> smaller integer.
    * Alternatively we could use a different constant for DWORD, BOOL and int if you want
* adds includes - i am not sure why `src/gmock-win32.cpp` compiles at all without this in msvc since it uses things from gmock and gtest without ever including it. This also fixes the problem that order of includes in user code would matter without them.

--
CI result here: <https://github.com/black-sliver/gmock-win32/actions/runs/13707973787>