### PR TITLE
fixed: Over-saturated GetCurrentThreadId for GTest ver: 1.15.0, 1.15.2, 1.16.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,6 +251,10 @@ int main(int argc, char* argv[])
 }
 ```
 
+# Known Limitations
+
+`gmock-win32` is not designed to be thread-safe; therefore, all expectations must be declared in the same thread as the API calls. All API calls made from other threads will be directed to the real functions.
+
 # Supported Platforms
 
 * C++ Version >= 14
@@ -267,12 +271,20 @@ int main(int argc, char* argv[])
 * `googletest 1.12.1`
 * `googletest 1.13.0`
 * `googletest 1.14.0`
+* `googletest 1.15.0`
+* `googletest 1.15.2`
+* `googletest 1.16.0`
 
 # Related Open Source Projects
 
 [GoogleTest](https://github.com/google/googletest)
 
 # Version history
+
+## Version 1.2.3 (10 March 2025)
+- Added compatibility with `GCC (MSYS2)`
+- Fixed several compilation warnings
+- Fixed over-saturated tests due to background GTest thread
 
 ## Version 1.2.2 (25 January 2024)
 - Added support for `Win32 API forwarding`

--- a/include/gmock-win32.h
+++ b/include/gmock-win32.h
@@ -86,6 +86,17 @@ namespace detail {
             static void* oldFn = nullptr;
             return &oldFn;
         }
+
+        static bool& has_expectations()
+        {
+            static thread_local bool value = false;
+            return value;
+        }
+
+        static void set_expectations(bool value)
+        {
+            has_expectations() = value;
+        }
     };
 
     void patch_module_func   (const char*, void*, void*, void**);
@@ -130,7 +141,7 @@ struct mock_module_##func : \
         GMOCK_MOCKER_(0, constness, func); \
     static GMOCK_RESULT_(tn, __VA_ARGS__) ct stub() \
     { \
-        if (gmock_win32::detail::lock) \
+        if (!has_expectations() || gmock_win32::detail::lock) \
         { \
             return reinterpret_cast< decltype(&stub) >(*pp_old_fn())(); \
         } \
@@ -171,7 +182,7 @@ struct mock_module_##func : \
     static GMOCK_RESULT_(tn, __VA_ARGS__) ct stub( \
         GMOCK_ARG_(tn, 1, __VA_ARGS__) gmock_a1) \
     { \
-        if (gmock_win32::detail::lock) \
+        if (!has_expectations() || gmock_win32::detail::lock) \
         { \
             return reinterpret_cast< decltype(&stub) >(*pp_old_fn())( \
                 gmock_a1); \
@@ -217,7 +228,7 @@ struct mock_module_##func : \
         GMOCK_ARG_(tn, 1, __VA_ARGS__) gmock_a1, \
         GMOCK_ARG_(tn, 2, __VA_ARGS__) gmock_a2) \
     { \
-        if (gmock_win32::detail::lock) \
+        if (!has_expectations() || gmock_win32::detail::lock) \
         { \
             return reinterpret_cast< decltype(&stub) >(*pp_old_fn())( \
                 gmock_a1, gmock_a2); \
@@ -266,7 +277,7 @@ struct mock_module_##func : \
         GMOCK_ARG_(tn, 2, __VA_ARGS__) gmock_a2, \
         GMOCK_ARG_(tn, 3, __VA_ARGS__) gmock_a3) \
     { \
-        if (gmock_win32::detail::lock) \
+        if (!has_expectations() || gmock_win32::detail::lock) \
         { \
             return reinterpret_cast< decltype(&stub) >(*pp_old_fn())( \
                 gmock_a1, gmock_a2, gmock_a3); \
@@ -318,7 +329,7 @@ struct mock_module_##func : \
         GMOCK_ARG_(tn, 3, __VA_ARGS__) gmock_a3, \
         GMOCK_ARG_(tn, 4, __VA_ARGS__) gmock_a4) \
     { \
-        if (gmock_win32::detail::lock) \
+        if (!has_expectations() || gmock_win32::detail::lock) \
         { \
             return reinterpret_cast< decltype(&stub) >(*pp_old_fn())( \
                 gmock_a1, gmock_a2, gmock_a3, gmock_a4); \
@@ -373,7 +384,7 @@ struct mock_module_##func : \
         GMOCK_ARG_(tn, 4, __VA_ARGS__) gmock_a4, \
         GMOCK_ARG_(tn, 5, __VA_ARGS__) gmock_a5) \
     { \
-        if (gmock_win32::detail::lock) \
+        if (!has_expectations() || gmock_win32::detail::lock) \
         { \
             return reinterpret_cast< decltype(&stub) >(*pp_old_fn())( \
                 gmock_a1, gmock_a2, gmock_a3, gmock_a4, gmock_a5); \
@@ -431,7 +442,7 @@ struct mock_module_##func : \
         GMOCK_ARG_(tn, 5, __VA_ARGS__) gmock_a5, \
         GMOCK_ARG_(tn, 6, __VA_ARGS__) gmock_a6) \
     { \
-        if (gmock_win32::detail::lock) \
+        if (!has_expectations() || gmock_win32::detail::lock) \
         { \
             return reinterpret_cast< decltype(&stub) >(*pp_old_fn())( \
                 gmock_a1, gmock_a2, gmock_a3, gmock_a4, gmock_a5, gmock_a6); \
@@ -492,7 +503,7 @@ struct mock_module_##func : \
         GMOCK_ARG_(tn, 6, __VA_ARGS__) gmock_a6, \
         GMOCK_ARG_(tn, 7, __VA_ARGS__) gmock_a7) \
     { \
-        if (gmock_win32::detail::lock) \
+        if (!has_expectations() || gmock_win32::detail::lock) \
         { \
             return reinterpret_cast< decltype(&stub) >(*pp_old_fn())( \
                 gmock_a1, gmock_a2, gmock_a3, gmock_a4, gmock_a5, gmock_a6, gmock_a7); \
@@ -556,7 +567,7 @@ struct mock_module_##func : \
         GMOCK_ARG_(tn, 7, __VA_ARGS__) gmock_a7, \
         GMOCK_ARG_(tn, 8, __VA_ARGS__) gmock_a8) \
     { \
-        if (gmock_win32::detail::lock) \
+        if (!has_expectations() || gmock_win32::detail::lock) \
         { \
             return reinterpret_cast< decltype(&stub) >(*pp_old_fn())( \
                 gmock_a1, gmock_a2, gmock_a3, gmock_a4, gmock_a5, gmock_a6, gmock_a7, gmock_a8); \
@@ -623,7 +634,7 @@ struct mock_module_##func : \
         GMOCK_ARG_(tn, 8, __VA_ARGS__) gmock_a8, \
         GMOCK_ARG_(tn, 9, __VA_ARGS__) gmock_a9) \
     { \
-        if (gmock_win32::detail::lock) \
+        if (!has_expectations() || gmock_win32::detail::lock) \
         { \
             return reinterpret_cast< decltype(&stub) >(*pp_old_fn())( \
                 gmock_a1, gmock_a2, gmock_a3, gmock_a4, gmock_a5, gmock_a6, gmock_a7, gmock_a8, gmock_a9); \
@@ -693,7 +704,7 @@ struct mock_module_##func : \
         GMOCK_ARG_(tn, 9, __VA_ARGS__) gmock_a9, \
         GMOCK_ARG_(tn, 10, __VA_ARGS__) gmock_a10) \
     { \
-        if (gmock_win32::detail::lock) \
+        if (!has_expectations() || gmock_win32::detail::lock) \
         { \
             return reinterpret_cast< decltype(&stub) >(*pp_old_fn())( \
                 gmock_a1, gmock_a2, gmock_a3, gmock_a4, gmock_a5, gmock_a6, gmock_a7, gmock_a8, gmock_a9, gmock_a10); \
@@ -766,7 +777,7 @@ struct mock_module_##func : \
         GMOCK_ARG_(tn, 10, __VA_ARGS__) gmock_a10, \
         GMOCK_ARG_(tn, 11, __VA_ARGS__) gmock_a11) \
     { \
-        if (gmock_win32::detail::lock) \
+        if (!has_expectations() || gmock_win32::detail::lock) \
         { \
             return reinterpret_cast< decltype(&stub) >(*pp_old_fn())( \
                 gmock_a1, gmock_a2, gmock_a3, gmock_a4, gmock_a5, gmock_a6, gmock_a7, gmock_a8, gmock_a9, gmock_a10, gmock_a11); \
@@ -842,7 +853,7 @@ struct mock_module_##func : \
         GMOCK_ARG_(tn, 11, __VA_ARGS__) gmock_a11, \
         GMOCK_ARG_(tn, 12, __VA_ARGS__) gmock_a12) \
     { \
-        if (gmock_win32::detail::lock) \
+        if (!has_expectations() || gmock_win32::detail::lock) \
         { \
             return reinterpret_cast< decltype(&stub) >(*pp_old_fn())( \
                 gmock_a1, gmock_a2, gmock_a3, gmock_a4, gmock_a5, gmock_a6, gmock_a7, gmock_a8, gmock_a9, gmock_a10, gmock_a11, gmock_a12); \
@@ -921,7 +932,7 @@ struct mock_module_##func : \
         GMOCK_ARG_(tn, 12, __VA_ARGS__) gmock_a12, \
         GMOCK_ARG_(tn, 13, __VA_ARGS__) gmock_a13) \
     { \
-        if (gmock_win32::detail::lock) \
+        if (!has_expectations() || gmock_win32::detail::lock) \
         { \
             return reinterpret_cast< decltype(&stub) >(*pp_old_fn())( \
                 gmock_a1, gmock_a2, gmock_a3, gmock_a4, gmock_a5, gmock_a6, gmock_a7, gmock_a8, gmock_a9, gmock_a10, gmock_a11, gmock_a12, gmock_a13); \
@@ -988,6 +999,7 @@ struct mock_module_##func : \
 #define MODULE_FUNC_CALL_IMPL_(EXPECTATION_, func, ...) \
     patch_module_func_##func(); \
     ++gmock_win32::detail::lock; \
+    mock_module_##func::set_expectations(true); \
     static_cast< decltype(EXPECTATION_(mock_module_##func::instance(), \
         func(__VA_ARGS__)))& >(gmock_win32::detail::make_proxy( \
             EXPECTATION_(mock_module_##func::instance(), func(__VA_ARGS__))))
@@ -1012,12 +1024,14 @@ struct mock_module_##func : \
 // Verifying and removing expectations
 
 #define VERIFY_AND_CLEAR_MODULE_FUNC_IMPL_(func) \
+    mock_module_##func::set_expectations(false); \
     ::testing::Mock::VerifyAndClear(&mock_module_##func::instance())
 
 #define VERIFY_AND_CLEAR_MODULE_FUNC(func) \
     VERIFY_AND_CLEAR_MODULE_FUNC_IMPL_(func)
 
 #define VERIFY_AND_CLEAR_MODULE_FUNC_EXPECTATIONS_IMPL_(func) \
+    mock_module_##func::set_expectations(false); \
     ::testing::Mock::VerifyAndClearExpectations(&mock_module_##func::instance())
 
 #define VERIFY_AND_CLEAR_MODULE_FUNC_EXPECTATIONS(func) \

--- a/src/gmock-win32.cpp
+++ b/src/gmock-win32.cpp
@@ -136,7 +136,8 @@ namespace utils {
         template< typename FuncType >
         void setupProcAddr(const HMODULE hmodule, const char* name, FuncType& pfnProc) noexcept
         {
-            pfnProc = reinterpret_cast< FuncType >(::GetProcAddress(hmodule, name));
+            pfnProc = reinterpret_cast< FuncType >(
+                reinterpret_cast< void* >(::GetProcAddress(hmodule, name)));
         }
 
     private:

--- a/tests/from0ToMax.cpp
+++ b/tests/from0ToMax.cpp
@@ -1,6 +1,4 @@
-﻿#include "gtest\gtest.h"
-#include "gmock\gmock.h"
-#include "gmock-win32.h"
+﻿#include "gmock-win32.h"
 #include <Windows.h>
 
 // 'reinterpret_cast': pointer truncation from 'HANDLE' to 'DWORD'
@@ -9,6 +7,23 @@
 #ifdef __clang__
 #	pragma clang diagnostic ignored "-Wvoid-pointer-to-int-cast"
 #endif // __clang__
+
+MOCK_STDCALL_FUNC(DWORD, GetCurrentThreadId);
+
+TEST(GetCurrentThreadIdTest, BypassMocks)
+{
+    ON_MODULE_FUNC_CALL(GetCurrentThreadId).WillByDefault(testing::Return(42U));
+    EXPECT_MODULE_FUNC_CALL(GetCurrentThreadId).Times(2);
+
+    const auto tid1 = ::GetCurrentThreadId();
+    const auto tid2 = ::GetCurrentThreadId();
+
+    BYPASS_MOCKS(EXPECT_EQ(tid1, 42U));
+    BYPASS_MOCKS(EXPECT_EQ(tid2, 42U));
+
+    RESTORE_MODULE_FUNC(GetCurrentThreadId);
+    VERIFY_AND_CLEAR_MODULE_FUNC_EXPECTATIONS(GetCurrentThreadId);
+}
 
 // 0
 MOCK_STDCALL_FUNC( HWINSTA, AnyPopup );

--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -1,11 +1,10 @@
-﻿#include "gtest\gtest.h"
-#include "gmock\gmock.h"
-#include "gmock-win32.h"
-#include <Windows.h>
+﻿#include "gmock-win32.h"
 
-int main(int argc, char **argv) {
+int main(int argc, char **argv)
+{
 	const gmock_win32::init_scope gmockWin32{ };
 	::testing::InitGoogleTest( &argc, argv );
+
 	std::cout << "Running main() from " << __FILE__ << std::endl;
 	return RUN_ALL_TESTS( );
 }


### PR DESCRIPTION
- Fixed over-saturation of tests caused by the background GTest thread by adding checks to ensure that expectations are set for the calling thread
- Added a comment to the `Known Limitations` section stating that the library is not designed to be thread-safe
- Added a test for mock bypassing and the background GTest thread
- Fixed warnings related to pointer casts