### PR TITLE
gcc: ignore function pointer cast warning

### DIFF
--- a/src/gmock-win32.cpp
+++ b/src/gmock-win32.cpp
@@ -10,6 +10,7 @@
 #pragma comment(lib, "dbghelp.lib")
 #else
 #include <dbghelp.h>
+#pragma GCC diagnostic ignored "-Wcast-function-type"
 #endif
 
 #include <memory>


### PR DESCRIPTION
As far as I understand, there is no clean way to use `GetProcAddress` from C++ when using GCC's `-Wcast-function-type` (which is part of `-Wextra`), because `FARPROC` is not a "function void pointer".
I want to build with `-Wextra -Werror`, and the least intrusive solution I came up with is disabling that one specific warning for that file by using a gcc pragma.

GCC documentation for the warning: <https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html#index-Wcast-function-type>
I believe this says that we could cast it twice (an intermediate `void(*)(void)`) to get rid of the warning, but I think that is even worse than the pragma? Lmk if I should investigate that path instead.

I am pretty sure clang understands `#pragma GCC` and I believe gtest is only supported on msvc, gcc and clang, so this pragma should not break anything.